### PR TITLE
Issue #130 Retry from loading page if status code is not 2xx

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"errors"
+
 	"github.com/fabric8-services/fabric8-jenkins-proxy/clients"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/storage"
 	"github.com/patrickmn/go-cache"
@@ -415,7 +416,7 @@ func (p *Proxy) processTemplate(w http.ResponseWriter, ns string) (err error) {
 		Retry   int
 	}{
 		Message: "Jenkins has been idled. It is starting now, please wait...",
-		Retry:   10,
+		Retry:   15,
 	}
 	log.WithField("ns", ns).Debug("Templating index.html")
 	err = tmplt.Execute(w, data)

--- a/static/html/index.html
+++ b/static/html/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>    
     <script type="application/javascript">
+      var timeout = {{.Retry}}*1000
       $(document).ready(function() {
         function check() {
           console.log("Checking "+window.location)
@@ -16,17 +17,21 @@
             statusCode: {
               202: function(){
                 console.log("Got 202, waiting along..")
-                setTimeout(check, {{.Retry}}*1000)
+                setTimeout(check, timeout)
                 },
               200: function() {
                 console.log("Got 200, reloading...")
                 window.location.reload(true)
                 }
+              default: function(xhr, status, e) {
+                console.log(status)
+                setTimeout(check, timeout)
+              }
             }          
           });
         }
 
-        setTimeout(check, {{.Retry}}*1000);
+        setTimeout(check, timeout);
       });
     </script>
     <style>


### PR DESCRIPTION
As described in #126 , this PR handles the case where request Proxy -> Jenkins takes longer to return than User -> Proxy

I've also increased the time to re-check is Jenkins is still idled from 10 to 15 seconds - I think we could go even higher as we know unidling generally takes ~2-3 minutes