### PR TITLE
Issue #139 Always set content type for webhook to json

### DIFF
--- a/scripts/webhook-migration/updateWebhooks.sh
+++ b/scripts/webhook-migration/updateWebhooks.sh
@@ -151,7 +151,7 @@ updateGitHubWebhooks() {
             echo " "
           else
             response=$(curl -sgSL -H "Authorization: token ${GITHUB_TOKENS[$i]}" -o /dev/null -w "%{http_code}" \
-              -X PATCH --data '{"config": {"url": "'${JENKINS_PROXY_URL}'github-webhook/"}}' \
+              -X PATCH --data '{"config": {"url": "'${JENKINS_PROXY_URL}'github-webhook/", "content_type": "json"}}' \
               https://api.github.com/repos/${REPOS[$i]}/hooks/${id})
             echo "${url} updated. Status: $response"
           fi


### PR DESCRIPTION
I've quickly tested it by building and pushing image and running a dry run in the cluster and it kept `json` type in place

Address issues #139