### PR TITLE
Issue #171 Fixed linting issues, Added `lint` in the `all` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ __check_defined = \
     $(if $(value $1),, \
       $(error Undefined $1$(if $2, ($2))))
 
-all: tools build test fmtcheck vet validate_commits image ## Compiles fabric8-jenkins-proxy and runs format and style checks
+.PHONY: all
+all: tools build test fmtcheck vet lint validate_commits image ## Compiles fabric8-jenkins-proxy and runs format and style checks
 
 build: vendor ## Builds the fabric8-jenkins-proxy into $GOPATH/bin
 	 go install -ldflags="$(LD_FLAGS)" ./cmd/fabric8-jenkins-proxy
@@ -43,6 +44,7 @@ $(BUILD_DIR)/fabric8-jenkins-proxy: vendor $(BUILD_DIR) ## Builds the Linux bina
 image: $(BUILD_DIR)/fabric8-jenkins-proxy ## Builds the fabric8-jenkins-proxy container image
 	docker build -t $(REGISTRY_URL) -f Dockerfile.deploy .
 
+.PHONY: push
 push: image ## Pushes the container image to the registry
 	$(call check_defined, REGISTRY_USER, "You need to pass the registry user via REGISTRY_USER.")
 	$(call check_defined, REGISTRY_PASSWORD, "You need to pass the registry password via REGISTRY_PASSWORD.")

--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -103,12 +103,12 @@ func start(config configuration.Configuration, tenant *clients.Tenant, wit *clie
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	startWorkers(&wg, ctx, cancel, store, &proxy, defaultStatsLoggingInterval, config.GetDebugMode())
+	startWorkers(ctx, &wg, cancel, store, &proxy, defaultStatsLoggingInterval, config.GetDebugMode())
 	setupSignalChannel(cancel)
 	wg.Wait()
 }
 
-func startWorkers(wg *sync.WaitGroup, ctx context.Context, cancel context.CancelFunc, store storage.Store, proxy *proxy.Proxy, interval time.Duration, addProfiler bool) {
+func startWorkers(ctx context.Context, wg *sync.WaitGroup, cancel context.CancelFunc, store storage.Store, proxy *proxy.Proxy, interval time.Duration, addProfiler bool) {
 	mainLogger.Info("Starting  all workers")
 	wg.Add(1)
 	go func() {
@@ -207,6 +207,7 @@ func startWorkers(wg *sync.WaitGroup, ctx context.Context, cancel context.Cancel
 	}
 }
 
+// createProxyRouter is the HTTP server handler which handles the incoming webhook and UI requests.
 func createProxyRouter(proxy *proxy.Proxy) *http.ServeMux {
 	proxyMux := http.NewServeMux()
 	proxyMux.HandleFunc("/", proxy.Handle)

--- a/cmd/osio/cmd/root.go
+++ b/cmd/osio/cmd/root.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"strings"
 )
 
 const (
@@ -11,6 +12,7 @@ const (
 )
 
 var (
+	// RootCmd is for using Cobra library for setting up command line interactions.
 	RootCmd   *cobra.Command
 	targetEnv string
 )

--- a/cmd/osio/cmd/token.go
+++ b/cmd/osio/cmd/token.go
@@ -6,8 +6,9 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"fmt"
-	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/util"
 	"net/url"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/util"
 )
 
 var (
@@ -18,7 +19,7 @@ var (
 		Run:   runCreateToken,
 	}
 	privateKey   string
-	privateKeyId string
+	privateKeyID string
 	uuid         string
 	session      string
 	validFor     int64
@@ -26,14 +27,14 @@ var (
 
 func init() {
 	cmdToken.Flags().StringVarP(&privateKey, "key", "k", "", "Private key.")
-	cmdToken.Flags().StringVarP(&privateKeyId, "id", "i", "", "Private key id (optional).")
+	cmdToken.Flags().StringVarP(&privateKeyID, "id", "i", "", "Private key id (optional).")
 	cmdToken.Flags().StringVarP(&uuid, "uuid", "u", "", "The users uuid.")
 	cmdToken.Flags().StringVarP(&session, "session", "s", "", "A session state string (optional).")
 	cmdToken.Flags().Int64VarP(&validFor, "valid", "v", 60, "Time token is valid in minutes (default 60).")
 }
 
 func runCreateToken(cmd *cobra.Command, args []string) {
-	token, err := util.CreateOSIOToken(targetEnv, uuid, privateKey, privateKeyId, validFor, session)
+	token, err := util.CreateOSIOToken(targetEnv, uuid, privateKey, privateKeyID, validFor, session)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,20 +19,22 @@ type proxy struct {
 	storageService storage.Store
 }
 
+// NewAPI creates an instance of ProxyAPI on taking a storage/database service as input.
 func NewAPI(storageService storage.Store) ProxyAPI {
 	return &proxy{
 		storageService: storageService,
 	}
 }
 
-type APIResponse struct {
+// Response contains Proxy usage statistics.
+type Response struct {
 	Namespace   string `json:"namespace"`
 	Requests    int    `json:"requests"`
 	LastVisit   int64  `json:"last_visit"`
 	LastRequest int64  `json:"last_request"`
 }
 
-//Info returns JSON including information about Proxy usage statistics for a given namespace
+// Info returns JSON including information about Proxy usage statistics for a given namespace.
 func (api *proxy) Info(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ns := ps.ByName("namespace")
 	s, notFound, err := api.storageService.GetStatisticsUser(ns)
@@ -51,7 +53,7 @@ func (api *proxy) Info(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		fmt.Fprintf(w, "{'error': '%s'}", err)
 		return
 	}
-	resp := APIResponse{
+	resp := Response{
 		Namespace:   ns,
 		Requests:    c,
 		LastRequest: s.LastBufferedRequest,

--- a/internal/clients/tenant.go
+++ b/internal/clients/tenant.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// NewTenant returns new Tenant client
+// NewTenant returns new Tenant client.
 func NewTenant(tenantServiceURL string, authToken string) Tenant {
 	logger := log.WithFields(
 		log.Fields{
@@ -29,7 +29,7 @@ func NewTenant(tenantServiceURL string, authToken string) Tenant {
 	}
 }
 
-//Tenant is a simple client for fabric8-tenant
+// Tenant is a simple client for fabric8-tenant.
 type Tenant struct {
 	tenantServiceURL string
 	authToken        string
@@ -37,6 +37,7 @@ type Tenant struct {
 	logger           *log.Entry
 }
 
+// TenantInfoList is a list of tenant information.
 type TenantInfoList struct {
 	Data []TenantInfoData
 	Meta struct {
@@ -44,28 +45,34 @@ type TenantInfoList struct {
 	}
 	Errors []Error `json:"errors"`
 }
+
+// TenantInfo gives imformation about tenant.
 type TenantInfo struct {
 	Data   TenantInfoData
 	Errors []Error `json:"errors"`
 }
 
+// Error describes an HTTP error consisting of error code and its details.
 type Error struct {
 	Code   string `json:"code"`
 	Detail string `json:"detail"`
 }
 
+// TenantInfoData give data about information such as attributes, id and type.
 type TenantInfoData struct {
 	Attributes Attributes
-	Id         string
+	ID         string
 	Type       string
 }
 
+// Attributes consists of time when the tenant was created, email and list namespaces belonging to that tenant.
 type Attributes struct {
 	CreatedAt  time.Time `json:"created-at"`
 	Email      string
 	Namespaces []Namespace
 }
 
+// Namespace is a tenant space in which each username is unique.
 type Namespace struct {
 	ClusterURL string `json:"cluster-url"`
 	Name       string
@@ -73,7 +80,7 @@ type Namespace struct {
 	Type       string
 }
 
-// GetTenantInfo returns a tenant information based on tenant id
+// GetTenantInfo returns a tenant information based on tenant id.
 func (t Tenant) GetTenantInfo(tenantID string) (ti TenantInfo, err error) {
 	if len(tenantID) == 0 {
 		err = errors.New("tenant ID cannot be empty string")
@@ -108,7 +115,7 @@ func (t Tenant) GetTenantInfo(tenantID string) (ti TenantInfo, err error) {
 	return
 }
 
-// GetNamespaceByType searches tenant namespaces for a given type
+// GetNamespaceByType searches tenant namespaces for a given type.
 func (t Tenant) GetNamespaceByType(ti TenantInfo, typ string) (r Namespace, err error) {
 	for i := 0; i < len(ti.Data.Attributes.Namespaces); i++ {
 		n := ti.Data.Attributes.Namespaces[i]

--- a/internal/clients/wit.go
+++ b/internal/clients/wit.go
@@ -9,12 +9,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// WIT describes work item tracker service of OSIO.
 type WIT struct {
 	witURL    string
 	authToken string
 	client    *http.Client
 }
 
+// NewWIT creates an instance of WIT client.
 func NewWIT(url string, token string) WIT {
 	return WIT{
 		witURL:    url,
@@ -23,18 +25,18 @@ func NewWIT(url string, token string) WIT {
 	}
 }
 
-//WITInfo holds information about owner of a git repository
+// WITInfo holds information about owner of a git repository.
 type WITInfo struct {
 	OwnedBy string
 }
 
-//UnmarshalJSON parses byte slice representing quite complicated API response into a simple struct
+// UnmarshalJSON parses byte slice representing quite complicated API response into a simple struct.
 func (wi *WITInfo) UnmarshalJSON(b []byte) (err error) {
 	type data struct {
 		Relationships struct {
 			Space struct {
 				Data struct {
-					Id string
+					ID string
 				}
 			}
 		}
@@ -43,13 +45,13 @@ func (wi *WITInfo) UnmarshalJSON(b []byte) (err error) {
 	type relationships struct {
 		OwnedBy struct {
 			Data struct {
-				Id string
+				ID string
 			}
 		} `json:"owned-by"`
 	}
 
 	type included struct {
-		Id            string
+		ID            string
 		Type          string
 		Relationships relationships
 	}
@@ -67,8 +69,8 @@ func (wi *WITInfo) UnmarshalJSON(b []byte) (err error) {
 
 	for _, d := range i.Data {
 		for _, i := range i.Included {
-			if d.Relationships.Space.Data.Id == i.Id { //Find correct Relationship
-				wi.OwnedBy = i.Relationships.OwnedBy.Data.Id
+			if d.Relationships.Space.Data.ID == i.ID { // Find correct Relationship
+				wi.OwnedBy = i.Relationships.OwnedBy.Data.ID
 				return nil
 			}
 		}
@@ -77,7 +79,7 @@ func (wi *WITInfo) UnmarshalJSON(b []byte) (err error) {
 	return nil
 }
 
-//SearchCodebase finds and returns owner of a given repository based on URL
+// SearchCodebase finds and returns owner of a given repository based on URL.
 func (w WIT) SearchCodebase(repo string) (*WITInfo, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/search/codebases", w.witURL), nil)
 	if err != nil {

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -1,5 +1,6 @@
 package configuration
 
+// Configuration declares methods to get configuration of the proxy.
 type Configuration interface {
 	// GetPostgresHost returns the postgres host as set via default, config file, or environment variable
 	GetPostgresHost() string
@@ -22,7 +23,7 @@ type Configuration interface {
 	// GetPostgresConnectionTimeout returns the postgres connection timeout as set via default, config file, or environment variable
 	GetPostgresConnectionTimeout() int
 
-	// GetPostgresConnectionMaxIdle returns the number of connections that should be keept alive in the database connection pool at
+	// GetPostgresConnectionMaxIdle returns the number of connections that should be kept alive in the database connection pool at
 	// any given time. -1 represents no restrictions/default behavior
 	GetPostgresConnectionMaxIdle() int
 

--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -2,13 +2,14 @@ package configuration
 
 import (
 	"fmt"
-	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/util"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/util"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -53,33 +54,36 @@ func init() {
 	settings["GetDebugMode"] = Setting{"JC_DEBUG_MODE", defaultDebugMode, []func(interface{}, string) error{util.IsBool}}
 }
 
+// Setting is an element in the proxy configuration. It contains the environment
+// variable from which the setting is retrieved, its default value as well as a list
+// of validations which the value of this setting needs to pass.
 type Setting struct {
 	key          string
 	defaultValue string
 	validations  []func(interface{}, string) error
 }
 
-// EnvConfig reads the configuration from the environment
+// EnvConfig is a Configuration implementation which reads the configuration from the process environment.
 type EnvConfig struct {
 	clusters map[string]string
 }
 
-// NewConfiguration creates a configuration instance
+// NewConfiguration creates a configuration instance.
 func NewConfiguration() (Configuration, error) {
-	//Check if we have all we need
+	// Check if we have all we need.
 	multiError := verifyEnv()
 	if !multiError.Empty() {
 		for _, err := range multiError.Errors {
 			logger.Error(err)
 		}
-		return nil, errors.New("One or more required environment variables are missing or invalid.")
+		return nil, errors.New("one or more required environment variables are missing or invalid")
 	}
 
 	config := EnvConfig{}
 	return &config, nil
 }
 
-// GetPostgresHost returns the postgres host as set via default, config file, or environment variable
+// GetPostgresHost returns the postgres host as set via default, config file, or environment variable.
 func (c *EnvConfig) GetPostgresHost() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -87,7 +91,7 @@ func (c *EnvConfig) GetPostgresHost() string {
 	return value
 }
 
-// GetPostgresPort returns the postgres port as set via default, config file, or environment variable
+// GetPostgresPort returns the postgres port as set via default, config file, or environment variable.
 func (c *EnvConfig) GetPostgresPort() int {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -96,7 +100,7 @@ func (c *EnvConfig) GetPostgresPort() int {
 	return i
 }
 
-// GetPostgresUser returns the postgres user as set via default, config file, or environment variable
+// GetPostgresUser returns the postgres user as set via default, config file, or environment variable.
 func (c *EnvConfig) GetPostgresUser() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -104,7 +108,7 @@ func (c *EnvConfig) GetPostgresUser() string {
 	return value
 }
 
-// GetPostgresDatabase returns the postgres database as set via default, config file, or environment variable
+// GetPostgresDatabase returns the postgres database as set via default, config file, or environment variable.
 func (c *EnvConfig) GetPostgresDatabase() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -112,7 +116,7 @@ func (c *EnvConfig) GetPostgresDatabase() string {
 	return value
 }
 
-// GetPostgresPassword returns the postgres password as set via default, config file, or environment variable
+// GetPostgresPassword returns the postgres password as set via default, config file, or environment variable.
 func (c *EnvConfig) GetPostgresPassword() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -120,7 +124,7 @@ func (c *EnvConfig) GetPostgresPassword() string {
 	return value
 }
 
-// GetPostgresSSLMode returns the postgres sslmode as set via default, config file, or environment variable
+// GetPostgresSSLMode returns the postgres sslmode as set via default, config file, or environment variable.
 func (c *EnvConfig) GetPostgresSSLMode() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -128,7 +132,7 @@ func (c *EnvConfig) GetPostgresSSLMode() string {
 	return value
 }
 
-// GetPostgresConnectionTimeout returns the postgres connection timeout as set via default, config file, or environment variable
+// GetPostgresConnectionTimeout returns the postgres connection timeout as set via default, config file, or environment variable.
 func (c *EnvConfig) GetPostgresConnectionTimeout() int {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -138,7 +142,7 @@ func (c *EnvConfig) GetPostgresConnectionTimeout() int {
 }
 
 // GetPostgresConnectionMaxIdle returns the number of connections that should be keept alive in the database connection pool at
-// any given time. -1 represents no restrictions/default behavior
+// any given time. -1 represents no restrictions/default behavior.
 func (c *EnvConfig) GetPostgresConnectionMaxIdle() int {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -148,7 +152,7 @@ func (c *EnvConfig) GetPostgresConnectionMaxIdle() int {
 }
 
 // GetPostgresConnectionMaxOpen returns the max number of open connections that should be open in the database connection pool.
-// -1 represents no restrictions/default behavior
+// -1 represents no restrictions/default behavior.
 func (c *EnvConfig) GetPostgresConnectionMaxOpen() int {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -157,7 +161,7 @@ func (c *EnvConfig) GetPostgresConnectionMaxOpen() int {
 	return i
 }
 
-// GetIdlerURL returns the Idler API URL as set via default, config file, or environment variable
+// GetIdlerURL returns the Idler API URL as set via default, config file, or environment variable.
 func (c *EnvConfig) GetIdlerURL() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -165,7 +169,7 @@ func (c *EnvConfig) GetIdlerURL() string {
 	return value
 }
 
-// GetAuthURL returns the Auth API URL as set via default, config file, or environment variable
+// GetAuthURL returns the Auth API URL as set via default, config file, or environment variable.
 func (c *EnvConfig) GetAuthURL() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -173,7 +177,7 @@ func (c *EnvConfig) GetAuthURL() string {
 	return value
 }
 
-// GetTenantURL returns the F8 Tenant API URL as set via default, config file, or environment variable
+// GetTenantURL returns the F8 Tenant API URL as set via default, config file, or environment variable.
 func (c *EnvConfig) GetTenantURL() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -181,7 +185,7 @@ func (c *EnvConfig) GetTenantURL() string {
 	return value
 }
 
-// GetWitURL returns the WIT API URL as set via default, config file, or environment variable
+// GetWitURL returns the WIT API URL as set via default, config file, or environment variable.
 func (c *EnvConfig) GetWitURL() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -189,7 +193,7 @@ func (c *EnvConfig) GetWitURL() string {
 	return value
 }
 
-// GetKeycloakURL returns the Keycloak API URL as set via default, config file, or environment variable
+// GetKeycloakURL returns the Keycloak API URL as set via default, config file, or environment variable.
 func (c *EnvConfig) GetKeycloakURL() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -197,7 +201,7 @@ func (c *EnvConfig) GetKeycloakURL() string {
 	return value
 }
 
-// GetAuthToken returns the Auth token as set via default, config file, or environment variable
+// GetAuthToken returns the Auth token as set via default, config file, or environment variable.
 func (c *EnvConfig) GetAuthToken() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -205,7 +209,7 @@ func (c *EnvConfig) GetAuthToken() string {
 	return value
 }
 
-// GetRedirectURL returns the redirect url to be passed to Auth as set via default, config file, or environment variable
+// GetRedirectURL returns the redirect url to be passed to Auth as set via default, config file, or environment variable.
 func (c *EnvConfig) GetRedirectURL() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -213,7 +217,7 @@ func (c *EnvConfig) GetRedirectURL() string {
 	return value
 }
 
-// GetIndexPath returns the path to loading page template as set via default, config file, or environment variable
+// GetIndexPath returns the path to loading page template as set via default, config file, or environment variable.
 func (c *EnvConfig) GetIndexPath() string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -222,7 +226,7 @@ func (c *EnvConfig) GetIndexPath() string {
 }
 
 // GetMaxRequestRetry returns the number of retries for webhook request forwarding as set via default, config file,
-// or environment variable
+// or environment variable.
 func (c *EnvConfig) GetMaxRequestRetry() int {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -231,7 +235,7 @@ func (c *EnvConfig) GetMaxRequestRetry() int {
 	return i
 }
 
-// GetDebugMode returns if debug mode should be enabled as set via default, config file, or environment variable
+// GetDebugMode returns if debug mode should be enabled as set via default, config file, or environment variable.
 func (c *EnvConfig) GetDebugMode() bool {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
@@ -257,7 +261,7 @@ func (c *EnvConfig) String() string {
 	return fmt.Sprintf("%v", config)
 }
 
-// Verify checks whether all needed config options are set
+// Verify checks whether all needed config options are set.
 func verifyEnv() util.MultiError {
 	var errors util.MultiError
 	for key, setting := range settings {

--- a/internal/proxy/proxy_cache.go
+++ b/internal/proxy/proxy_cache.go
@@ -1,14 +1,16 @@
 package proxy
 
-type ProxyCacheItem struct {
+// CacheItem represents a cache item  consisting of cluster URL, namespace, route, scheme(HTTP, HTTPS etc).
+type CacheItem struct {
 	ClusterURL string
 	NS         string
 	Route      string
 	Scheme     string
 }
 
-func NewProxyCacheItem(ns string, scheme string, route string, clusterURL string) ProxyCacheItem {
-	return ProxyCacheItem{
+// NewCacheItem creates an instance of cache item.
+func NewCacheItem(ns string, scheme string, route string, clusterURL string) CacheItem {
+	return CacheItem{
 		NS:         ns,
 		Scheme:     scheme,
 		Route:      route,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -5,6 +5,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// CreateAPIRouter is creating a router for the REST API of the Proxy.
 func CreateAPIRouter(api api.ProxyAPI) *httprouter.Router {
 	// Create router for API
 	proxyRouter := httprouter.New()

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -45,8 +45,8 @@ func (i *mockProxyAPI) Info(w http.ResponseWriter, r *http.Request, ps httproute
 }
 
 func Test_all_routes_are_setup(t *testing.T) {
-	mockedProxyApi := &mockProxyAPI{}
-	mockedRouter := CreateAPIRouter(mockedProxyApi)
+	mockedProxyAPI := &mockProxyAPI{}
+	mockedRouter := CreateAPIRouter(mockedProxyAPI)
 
 	var routes = []struct {
 		route  string

--- a/internal/storage/db_store.go
+++ b/internal/storage/db_store.go
@@ -2,32 +2,40 @@ package storage
 
 import (
 	"fmt"
+
 	"github.com/jinzhu/gorm"
+	// Importing postgres driver to connect to the database
+	// The underscore import is used for the side-effect of a package.
 	_ "github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
 )
 
 var dbLogger = log.WithFields(log.Fields{"component": "db"})
 
+// NewDBStorage creates an instance of database client.
 func NewDBStorage(db *gorm.DB) Store {
 	return &DBStore{db: db}
 }
 
+// DBStore describes a database client.
 type DBStore struct {
 	db *gorm.DB
 }
 
+// CreateRequest creates an entry of request in the database.
 func (s *DBStore) CreateRequest(r *Request) error {
 	return s.db.Create(r).Error
 }
 
+// GetRequests gets one or more requests from the database given a namespace as input.
 func (s *DBStore) GetRequests(ns string) (result []Request, err error) {
 	var r Request
 	err = s.db.Table(r.TableName()).Where("namespace = ?", ns).Find(&result).Error
 	return
 }
 
-func (s *DBStore) IncRequestRetry(r *Request) (errs []error) {
+// IncrementRequestRetry increases retries for a given request in the database.
+func (s *DBStore) IncrementRequestRetry(r *Request) (errs []error) {
 	r.Retries++
 	err := s.updateRequest(r)
 	if err != nil {
@@ -41,6 +49,7 @@ func (s *DBStore) IncRequestRetry(r *Request) (errs []error) {
 	return
 }
 
+// GetUsers gets namespaces from the database.
 func (s *DBStore) GetUsers() (result []string, err error) {
 	var r Request
 
@@ -48,24 +57,29 @@ func (s *DBStore) GetUsers() (result []string, err error) {
 	return
 }
 
+// GetRequestsCount gets requests count given a namespace.
 func (s *DBStore) GetRequestsCount(ns string) (result int, err error) {
 	var r Request
 	err = s.db.Table(r.TableName()).Where("namespace = ?", ns).Count(&result).Error
 	return
 }
 
+// DeleteRequest deletes a request from the database.
 func (s *DBStore) DeleteRequest(r *Request) error {
 	return s.db.Delete(r).Error
 }
 
+// CreateStatistics creates an entry of Statistics in the database.
 func (s *DBStore) CreateStatistics(o *Statistics) error {
 	return s.db.Create(o).Error
 }
 
+// UpdateStatistics updates Statistics in the database.
 func (s *DBStore) UpdateStatistics(o *Statistics) error {
 	return s.db.Save(o).Error
 }
 
+// GetStatisticsUser gets Statistics of a namespace from the database.
 func (s *DBStore) GetStatisticsUser(ns string) (o *Statistics, notFound bool, err error) {
 	o = &Statistics{}
 	d := s.db.Table(o.TableName()).Find(
@@ -75,6 +89,7 @@ func (s *DBStore) GetStatisticsUser(ns string) (o *Statistics, notFound bool, er
 	return
 }
 
+// LogStats logs number of cached number of cached requests and statistics entries count.
 func (s *DBStore) LogStats() {
 	var requestCount, statisticCount int
 	s.db.Table("requests").Count(&requestCount)

--- a/internal/storage/request.go
+++ b/internal/storage/request.go
@@ -3,17 +3,20 @@ package storage
 import (
 	"bytes"
 	"encoding/json"
-	uuid "github.com/satori/go.uuid"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
+	// ErrorFailedDelete is the error message on failing to delete a request.
 	ErrorFailedDelete = "failed to delete request for %s (%s): %s"
 )
 
+// Request describes an HTTP request.
 type Request struct {
 	ID        uuid.UUID `sql:"type:uuid" gorm:"primary_key"` // This is the ID PK field
 	Method    string
@@ -26,6 +29,7 @@ type Request struct {
 	Retries   int
 }
 
+// NewRequest creates a new request for a namespace.
 func NewRequest(r *http.Request, ns string, body []byte) (*Request, error) {
 	h, err := json.Marshal(r.Header)
 	if err != nil {
@@ -45,20 +49,24 @@ func NewRequest(r *http.Request, ns string, body []byte) (*Request, error) {
 	}, nil
 }
 
+// TableName for current request.
 func (m Request) TableName() string {
 	return "requests"
 }
 
+// GetHeaders gets headers of the this request.
 func (m Request) GetHeaders() (result map[string][]string, err error) {
 	result = make(map[string][]string)
 	err = json.Unmarshal(m.Headers, &result)
 	return
 }
 
+// GetPayloadReader returns an io reader for the request payload.
 func (m Request) GetPayloadReader() io.ReadCloser {
 	return ioutil.NopCloser(bytes.NewReader(m.Payload))
 }
 
+// GetHTTPRequest wraps an *http.Request from this request.
 func (m Request) GetHTTPRequest() (r *http.Request, err error) {
 	u := url.URL{}
 	u.Host = m.Host

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -5,12 +5,14 @@ import (
 	"time"
 )
 
+// Statistics consists of namespace, last time time was accessed and last buffered request to that namespace.
 type Statistics struct {
 	Namespace           string `gorm:"primary_key"` // This is the ID PK field
 	LastAccessed        int64
 	LastBufferedRequest int64
 }
 
+// NewStatistics returns an instance of statistics on giving namespace, last accessed time and last buffered request as an input.
 func NewStatistics(ns string, la int64, lbr int64) *Statistics {
 	return &Statistics{
 		Namespace:           ns,
@@ -19,6 +21,7 @@ func NewStatistics(ns string, la int64, lbr int64) *Statistics {
 	}
 }
 
+// TableName returns table name for the given statistics.
 func (m Statistics) TableName() string {
 	return "statistics"
 }

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -3,13 +3,14 @@ package storage
 import (
 	"bytes"
 	"context"
-	log "github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 )
 
 // TODO turn this into a general in memory store service (HF)
@@ -25,7 +26,7 @@ func (m *mockStore) GetRequests(ns string) (result []Request, err error) {
 	return nil, nil
 }
 
-func (m *mockStore) IncRequestRetry(r *Request) (errs []error) {
+func (m *mockStore) IncrementRequestRetry(r *Request) (errs []error) {
 	return nil
 }
 

--- a/internal/testutils/common.go
+++ b/internal/testutils/common.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// MockServer creates a mock server for testing purpose.
 func MockServer(b []byte) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
@@ -20,6 +21,7 @@ func MockServer(b []byte) *httptest.Server {
 	}))
 }
 
+// MockRedirect does mock redirection and passes a JWT token along with the request
 func MockRedirect(url string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
@@ -36,6 +38,7 @@ func MockRedirect(url string) *httptest.Server {
 	}))
 }
 
+// MockJenkins returns a mock Jenkins server for testing.
 func MockJenkins() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
@@ -53,6 +56,7 @@ func MockJenkins() *httptest.Server {
 	}))
 }
 
+// MockOpenShift creates a mock openshift server.
 func MockOpenShift(url string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
@@ -67,6 +71,8 @@ func MockOpenShift(url string) *httptest.Server {
 	}))
 }
 
+// JenkinsStatus checks status of Jenkins
+// It return HTTP status code and 1 if Jenkins is active 0 if not active.
 func JenkinsStatus() (c int, r int) {
 	code, err := ioutil.ReadFile("code.txt")
 	if err != nil {
@@ -88,6 +94,7 @@ func JenkinsStatus() (c int, r int) {
 	return
 }
 
+// WITData1 returns some sample work item tracker data.
 func WITData1() []byte {
 	return []byte(`{
 		"data": [
@@ -248,6 +255,8 @@ func WITData1() []byte {
 	}`)
 }
 
+// IdlerData1 returns some sample idler related data when service in question is unidled
+// data such as service in question, its url,  etc.
 func IdlerData1(url string) []byte {
 	fmt.Printf(url)
 	tls := false
@@ -265,6 +274,7 @@ func IdlerData1(url string) []byte {
 		}`, url, tls))
 }
 
+// IdlerData2 returns some sample idler related data when the service in question(Jenkins here) is idled.
 func IdlerData2() []byte {
 	return []byte(`{
 		"service": "jenkins",
@@ -274,6 +284,8 @@ func IdlerData2() []byte {
 		}`)
 }
 
+// TenantData1 contains sample tenant data when jenkins service is unidled
+// data would include cluster url, email of user, etc.
 func TenantData1(url string) []byte {
 	if len(url) == 0 {
 		url = "https://api.free-int.openshift.com"
@@ -338,10 +350,13 @@ func TenantData1(url string) []byte {
 }`, url, url, url, url, url))
 }
 
+// TenantData2 contains sample tenant data when jenkins service is idled.
 func TenantData2() []byte {
 	return []byte(`{"errors":[{"code":"not_found","detail":"/","id":"2Q/BAc8b","status":"404","title":"Not Found"}]}`)
 }
 
+// TenantData3 contains sample tenant data when jenkins service is unidled
+// data would include cluster url, email of user, etc.
 func TenantData3() []byte {
 	return []byte(`
 		{
@@ -409,6 +424,8 @@ func TenantData3() []byte {
 	}`)
 }
 
+// GetGHData gets sample GHData.
+// GHData is data gathered by GitHub when a new commit occurs
 func GetGHData() []byte {
 	return []byte(`{
 		"ref": "refs/heads/master",
@@ -594,14 +611,18 @@ func GetGHData() []byte {
 	}`)
 }
 
+// AuthData1 return a sample JWT token as a query passed to a URL.
 func AuthData1() string {
 	return `?token_json=%7B"access_token"%3A"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ6RC01N29CRklNVVpzQVdxVW5Jc1Z1X3g3MVZJamQxaXJHa0dVT2lUc0w4In0.eyJqdGkiOiI0ZTczNzU3MC03MzMwLTRjMDctYWMzNS00MTkyNWE2Y2YzNmUiLCJleHAiOjE1MTgyNTM4NjksIm5iZiI6MCwiaWF0IjoxNTE1NjYxODY5LCJpc3MiOiJodHRwczovL3Nzby5wcm9kLXByZXZpZXcub3BlbnNoaWZ0LmlvL2F1dGgvcmVhbG1zL2ZhYnJpYzgiLCJhdWQiOiJmYWJyaWM4LW9ubGluZS1wbGF0Zm9ybSIsInN1YiI6IjJlMTVlOTU3LTAzNjYtNDgwMi1iZjFlLTBkNmZlM2YxMWJiNiIsInR5cCI6IkJlYXJlciIsImF6cCI6ImZhYnJpYzgtb25saW5lLXBsYXRmb3JtIiwiYXV0aF90aW1lIjoxNTE1MTYwMjQ2LCJzZXNzaW9uX3N0YXRlIjoiNDRlNDVjZDEtMmJmMC00ZjZlLTk1MzctZWZiYjk4ODI4YTA3IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyJodHRwczovL3Byb2QtcHJldmlldy5vcGVuc2hpZnQuaW8iLCJodHRwczovL2F1dGgucHJvZC1wcmV2aWV3Lm9wZW5zaGlmdC5pbyIsImh0dHA6Ly9jb3JlLXdpdC4xOTIuMTY4LjQyLjY5Lm5pcC5pbyIsImh0dHA6Ly9sb2NhbGhvc3Q6ODA4MCIsIioiLCJodHRwczovL2NvcmUtd2l0LjE5Mi4xNjguNDIuNjkubmlwLmlvIiwiaHR0cHM6Ly9hcGkucHJvZC1wcmV2aWV3Lm9wZW5zaGlmdC5pbyIsImh0dHA6Ly9sb2NhbGhvc3Q6MzAwMCIsImh0dHA6Ly9hdXRoLXdpdC4xOTIuMTY4LjQyLjY5Lm5pcC5pbyIsImh0dHBzOi8vYXV0aC13aXQuMTkyLjE2OC40Mi42OS5uaXAuaW8iLCJodHRwOi8vbG9jYWxob3N0OjgwODkiXSwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYnJva2VyIjp7InJvbGVzIjpbInJlYWQtdG9rZW4iXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sImFwcHJvdmVkIjp0cnVlLCJuYW1lIjoiVmFjbGF2IFBhdmxpbiIsImNvbXBhbnkiOiJSZWQgSGF0IiwicHJlZmVycmVkX3VzZXJuYW1lIjoidnBhdmxpbkByZWRoYXQuY29tIiwiZ2l2ZW5fbmFtZSI6IlZhY2xhdiIsImZhbWlseV9uYW1lIjoiUGF2bGluIiwiZW1haWwiOiJ2cGF2bGluQHJlZGhhdC5jb20ifQ.bRTpWRDfIdPavcWyF0UQQ0rCv_iDTaQsQ_sJ3XdOFTzxrAXD4dqGcssbyr8FzvfwfOrgl1Xee7Gd49Ll85UDMUdHAcjXhQHqThCV8CxE2OTrlM-thSIPCdC0cKOAfuoJ02x2YPcWRKP4KYw4dd0zRlcI_ZgBoYgRgofCYzJVSFAm2BdDmRQ-9DgAGkL0djB5FcC3TNCztqAGy53koRW4IJEIFuTbMO_Zink3xvFp31vzmG0Jyw8gS98CnE1ZYir09HU-Xjxr3qlYXV7r0LAcgUIQOWbL6Ok-KAxDcZxUxjQQP2LCYAoLRP35O4u2Bjr9xCnko6qY8rl6_2BBqN0fMw"%2C"expires_in"%3A2592000%2C"not-before-policy"%3Anull%2C"refresh_expires_in"%3A2592000%2C"refresh_token"%3A"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ6RC01N29CRklNVVpzQVdxVW5Jc1Z1X3g3MVZJamQxaXJHa0dVT2lUc0w4In0.eyJqdGkiOiIxYzJhZDJmNS05NDA0LTQyMDQtYTc3MC1jMTA0MmU0MmNiMzQiLCJleHAiOjE1MTgyNTM4NjksIm5iZiI6MCwiaWF0IjoxNTE1NjYxODY5LCJpc3MiOiJodHRwczovL3Nzby5wcm9kLXByZXZpZXcub3BlbnNoaWZ0LmlvL2F1dGgvcmVhbG1zL2ZhYnJpYzgiLCJhdWQiOiJmYWJyaWM4LW9ubGluZS1wbGF0Zm9ybSIsInN1YiI6IjJlMTVlOTU3LTAzNjYtNDgwMi1iZjFlLTBkNmZlM2YxMWJiNiIsInR5cCI6IlJlZnJlc2giLCJhenAiOiJmYWJyaWM4LW9ubGluZS1wbGF0Zm9ybSIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6IjQ0ZTQ1Y2QxLTJiZjAtNGY2ZS05NTM3LWVmYmI5ODgyOGEwNyIsInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImJyb2tlciI6eyJyb2xlcyI6WyJyZWFkLXRva2VuIl19LCJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19fQ.kL4pexAlr09ltckQYHNW8DenUGliGKi2edyGzL_BIxtrX3NUVHQxVSEFFxY9AoY9lzTgxFnycatML_4mCwGTK2Ezok4bisVMc3_yhE7AKwkleV5UyqcyVfRKT20V1w4aOU_64BAUi7Hxz1tRo26AON8P5q-6XT53srJgFXaPjypBml-3a-yu0eIorjx0KmNUQ6g3Vg41tGixPEAy1JYN-kPhR3PBZDLV7yVpNpfTEiTkdfpZ-9wEphw-rGhBZGnd8b57dzlkuGE5jPB33JpgH_IFf49o6wBZMIv5vA9M1mQlF2xIc7nAIeuaYKJZFzlOsx7s1rF-w79PDOJyN6ZF5g"%2C"token_type"%3A"bearer"%7D`
 }
 
+// AuthDataOSO return a sample OpenShift Online JWT token in JSON format.
 func AuthDataOSO() string {
 	return `{"access_token":"ZvOLzEbQ1Ml0AtT_q7HIl4SEM_qnbZ7WrlUNEmDhPsQ","scope":"user:full","token_type":"Bearer"}`
 }
 
+// OpenShiftIdle mock-changes Jenkins status in the DeploymentConfig
+// https://docs.openshift.com/online/rest_api/oapi/v1.DeploymentConfig.html#object-schema
 func OpenShiftIdle(i int) []byte {
 	return []byte(fmt.Sprintf(`
 		{
@@ -613,6 +634,8 @@ func OpenShiftIdle(i int) []byte {
 	`, i, i))
 }
 
+// OpenShiftDataRoute mock-changes host in the Route
+// https://docs.openshift.com/online/rest_api/oapi/v1.Route.html#object-schema
 func OpenShiftDataRoute(h string) []byte {
 	u, err := url.ParseRequestURI(h)
 	if err != nil {

--- a/internal/testutils/logging.go
+++ b/internal/testutils/logging.go
@@ -4,6 +4,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ExtractLogMessages extracts log messages from an array of *log.Entry and return an array of message strings.
 func ExtractLogMessages(entries []*log.Entry) []string {
 	messages := []string{}
 	for _, logEntry := range entries {

--- a/internal/testutils/mock/mock_config.go
+++ b/internal/testutils/mock/mock_config.go
@@ -1,5 +1,6 @@
 package mock
 
+// Config represents configuration required to run jenkins-proxy
 type Config struct {
 	PostgresHost              string
 	PostgresPort              int
@@ -23,6 +24,7 @@ type Config struct {
 	Clusters                  map[string]string
 }
 
+// NewConfig creates an instance of configuration
 func NewConfig() Config {
 	c := Config{}
 
@@ -45,78 +47,99 @@ func NewConfig() Config {
 	return c
 }
 
+// GetPostgresHost return hardcoded postgres host from test configuration.
 func (c *Config) GetPostgresHost() string {
 	return c.PostgresHost
 }
 
+// GetPostgresPort return hardcoded postgres porn from test configuration.
 func (c *Config) GetPostgresPort() int {
 	return c.PostgresPort
 }
 
+// GetPostgresUser return hardcoded postgres user from test configuration.
 func (c *Config) GetPostgresUser() string {
 	return c.PostgresUser
 }
 
+// GetPostgresDatabase return hardcoded postgres database name from test configuration.
 func (c *Config) GetPostgresDatabase() string {
 	return c.PostgresDatabase
 }
 
+// GetPostgresPassword return hardcoded postgres password from test configuration.
 func (c *Config) GetPostgresPassword() string {
 	return c.PostgresPassword
 }
 
+// GetPostgresSSLMode return hardcoded postgres ssl mode (ssl enabled or disabled) from test configuration.
 func (c *Config) GetPostgresSSLMode() string {
 	return c.PostgresSSLMode
 }
 
+// GetPostgresConnectionTimeout return hardcoded postgres connection timeout from test configuration.
 func (c *Config) GetPostgresConnectionTimeout() int {
 	return c.PostgresConnectionTimeout
 }
 
+// GetPostgresConnectionMaxIdle return hardcoded number of connections that should be kept alive in the database connection pool at any given time from test configuration.
+// Here it is set to -1, which represents no restrictions/default behavior.
 func (c *Config) GetPostgresConnectionMaxIdle() int {
 	return c.PostgresConnectionMaxIdle
 }
 
+// GetPostgresConnectionMaxOpen return hardcoded max number of open connections that should be open in the database connection pool from test configuration.
+// Here it is set to -1 represents no restrictions/default behavior.
 func (c *Config) GetPostgresConnectionMaxOpen() int {
 	return c.PostgresConnectionMaxOpen
 }
 
+// GetIdlerURL return hardcoded url of idler service from test configuration.
 func (c *Config) GetIdlerURL() string {
 	return c.IdlerURL
 }
 
+// GetAuthURL return hardcoded url of the fabric8-auth service from test configuration.
 func (c *Config) GetAuthURL() string {
 	return c.AuthURL
 }
 
+// GetTenantURL return hardcoded url of tenant service from test configuration.
 func (c *Config) GetTenantURL() string {
 	return c.TenantURL
 }
 
+// GetWitURL return hardcoded url of wit service from test configuration.
 func (c *Config) GetWitURL() string {
 	return c.WitURL
 }
 
+// GetKeycloakURL return hardcoded url of the keycloak server from test configuration.
 func (c *Config) GetKeycloakURL() string {
 	return c.KeycloakURL
 }
 
+// GetAuthToken return hardcoded value of auth token from test configuration.
 func (c *Config) GetAuthToken() string {
 	return c.AuthToken
 }
 
+// GetRedirectURL return hardcoded redirect url to be passed to the auth service from test configuration.
 func (c *Config) GetRedirectURL() string {
 	return c.RedirectURL
 }
 
+// GetIndexPath return hardcoded path to loading page template from test configuration.
 func (c *Config) GetIndexPath() string {
 	return c.IndexPath
 }
 
+// GetMaxRequestRetry return hardcoded number of retries for webhook request forwarding from test configuration.
 func (c *Config) GetMaxRequestRetry() int {
 	return c.MaxRequestRetry
 }
 
+// GetDebugMode return hardcoded debug mode from test configuration.
 func (c *Config) GetDebugMode() bool {
 	return c.DebugMode
 }

--- a/internal/util/common.go
+++ b/internal/util/common.go
@@ -6,11 +6,11 @@ const (
 )
 
 type environment struct {
-	osioUrl      string
-	apiUrl       string
+	osioURL      string
+	apiURL       string
 	authURL      string
 	redirectURL  string
-	privateKeyId string
+	privateKeyID string
 }
 
 var (
@@ -19,18 +19,18 @@ var (
 
 func init() {
 	environments[stage] = environment{
-		osioUrl:      "https://prod-preview.openshift.io",
-		apiUrl:       "https://api.openshift.io",
+		osioURL:      "https://prod-preview.openshift.io",
+		apiURL:       "https://api.openshift.io",
 		authURL:      "https://auth.prod-preview.openshift.io",
 		redirectURL:  "https://jenkins.prod-preview.openshift.io",
-		privateKeyId: "PE6-BEECZZpPZIVxLR6NinbthOHJcGqYrfl8v7v6BVA", // key id for serviceaccount.privatekey
+		privateKeyID: "PE6-BEECZZpPZIVxLR6NinbthOHJcGqYrfl8v7v6BVA", // key id for serviceaccount.privatekey
 	}
 
 	environments[prod] = environment{
-		osioUrl:      "https://openshift.io",
-		apiUrl:       "https://api.prod-preview.openshift.io",
+		osioURL:      "https://openshift.io",
+		apiURL:       "https://api.prod-preview.openshift.io",
 		authURL:      "https://auth.openshift.io",
 		redirectURL:  "https://jenkins.openshift.io",
-		privateKeyId: "quzUZlR_ollAUoAGgm165tYDTU3xtKon8O1RghJZ4TU", // key id for serviceaccount.privatekey
+		privateKeyID: "quzUZlR_ollAUoAGgm165tYDTU3xtKon8O1RghJZ4TU", // key id for serviceaccount.privatekey
 	}
 }

--- a/internal/util/jwt.go
+++ b/internal/util/jwt.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"fmt"
+
 	"github.com/pkg/errors"
 	"golang.org/x/net/html"
 )
@@ -16,6 +17,7 @@ const (
 	jsonToken = "token_json"
 )
 
+// CreateJWTToken gets raw jwt token from username, password and environment.
 func CreateJWTToken(env string, username string, password string) (string, error) {
 	environment, ok := environments[env]
 
@@ -56,7 +58,7 @@ func CreateJWTToken(env string, username string, password string) (string, error
 	}
 	defer resp.Body.Close()
 
-	postUrl, err := extractFormPostURL(resp)
+	postURL, err := extractFormPostURL(resp)
 	if err != nil {
 		return "", err
 	}
@@ -65,20 +67,20 @@ func CreateJWTToken(env string, username string, password string) (string, error
 	form.Add("password", password)
 	form.Add("login", "Log+in")
 
-	authResp, err := client.PostForm(postUrl, form)
+	authResp, err := client.PostForm(postURL, form)
 	if err != nil {
 		return "", err
 	}
 	defer authResp.Body.Close()
 
 	if len(token) == 0 {
-		return "", errors.New("Token could not be extracted.")
+		return "", errors.New("token could not be extracted")
 	}
 	return token, nil
 }
 
 func extractFormPostURL(resp *http.Response) (string, error) {
-	var postUrl string
+	var postURL string
 	doc, err := html.Parse(resp.Body)
 	if err != nil {
 		return "", err
@@ -88,7 +90,7 @@ func extractFormPostURL(resp *http.Response) (string, error) {
 		if n.Type == html.ElementNode && n.Data == "form" {
 			for _, attr := range n.Attr {
 				if attr.Key == "action" {
-					postUrl = attr.Val
+					postURL = attr.Val
 				}
 			}
 		}
@@ -97,5 +99,5 @@ func extractFormPostURL(resp *http.Response) (string, error) {
 		}
 	}
 	f(doc)
-	return postUrl, nil
+	return postURL, nil
 }

--- a/internal/util/logging/request.go
+++ b/internal/util/logging/request.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// FormatHTTPRequestWithSeparator returns a formatted and readable string containing information of given HTTP request, seperated by given seperated.
 func FormatHTTPRequestWithSeparator(r *http.Request, separator string) string {
 	var request []string
 
@@ -30,14 +31,17 @@ func FormatHTTPRequestWithSeparator(r *http.Request, separator string) string {
 	return strings.Join(request, separator)
 }
 
+// FormatHTTPRequest returns a formatted and readable string containing information of given HTTP request.
 func FormatHTTPRequest(r *http.Request) string {
 	return FormatHTTPRequestWithSeparator(r, "\n")
 }
 
+// RequestMethodAndURL return string containing method(GET, POST, PATCH etc) and string given an HTTP request.
 func RequestMethodAndURL(r *http.Request) string {
 	return fmt.Sprintf("%v %v", r.Method, r.URL)
 }
 
+// RequestHeaders returns a string containing request header for the given HTTP request.
 func RequestHeaders(r *http.Request) string {
 	var result []string
 	for name, headers := range r.Header {
@@ -46,7 +50,7 @@ func RequestHeaders(r *http.Request) string {
 		}
 	}
 
-	// to ensure consistency we force an order
+	// to ensure consistency we force an order.
 	sort.Strings(result)
 	return strings.Join(result, " ")
 }

--- a/internal/util/logging/request_test.go
+++ b/internal/util/logging/request_test.go
@@ -1,10 +1,11 @@
 package logging
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/internal/util/multi_error.go
+++ b/internal/util/multi_error.go
@@ -5,20 +5,25 @@ import (
 	"strings"
 )
 
+// MultiError is a collection of errors.
 type MultiError struct {
 	Errors []error
 }
 
+// Empty returns true if current MuiltiError is empty,
+// false otherwise.
 func (m *MultiError) Empty() bool {
 	return len(m.Errors) == 0
 }
 
+// Collect appends an error to this MultiError.
 func (m *MultiError) Collect(err error) {
 	if err != nil {
 		m.Errors = append(m.Errors, err)
 	}
 }
 
+// ToError returns a single error made up of all errors in this MultiError.
 func (m MultiError) ToError() error {
 	if len(m.Errors) == 0 {
 		return nil

--- a/internal/util/reflect.go
+++ b/internal/util/reflect.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 )
 
+// NameOfFunction gives name of the current function given program counter.
 func NameOfFunction(pc uintptr) string {
 	name := ""
 	if rf := runtime.FuncForPC(pc); rf != nil {

--- a/internal/util/validations.go
+++ b/internal/util/validations.go
@@ -2,12 +2,15 @@ package util
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
+// IsNotEmpty checks if value stored at given key is empty.
+// if it is empty it returns an error.
 func IsNotEmpty(value interface{}, key string) error {
 	s, ok := value.(string)
 	if !ok {
@@ -21,6 +24,7 @@ func IsNotEmpty(value interface{}, key string) error {
 
 }
 
+// IsURL checks if value store at an given key is an URL.
 func IsURL(value interface{}, key string) error {
 	s, ok := value.(string)
 	if !ok {
@@ -38,6 +42,7 @@ func IsURL(value interface{}, key string) error {
 	return nil
 }
 
+// IsInt checks if values stored at a given key is an int.
 func IsInt(value interface{}, key string) error {
 	_, err := strconv.Atoi(value.(string))
 	if err != nil {
@@ -46,6 +51,7 @@ func IsInt(value interface{}, key string) error {
 	return nil
 }
 
+// IsBool checks if value stored at a given key is a bool.
 func IsBool(value interface{}, key string) error {
 	_, err := strconv.ParseBool(value.(string))
 	if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,6 +4,7 @@ var (
 	version = "unset"
 )
 
+// GetVersion return current version of the API.
 func GetVersion() string {
 	return version
 }


### PR DESCRIPTION
I would need help with what is remaining.
```
internal/proxy/proxy.go:32:2: exported const GHHeader should have comment (or a comment on this block) or be unexported
internal/router/router.go:8:1: exported function CreateAPIRouter should have comment or be unexported
internal/router/router_test.go:48:2: var mockedProxyApi should be mockedProxyAPI
internal/testutils/common.go:24:1: exported function MockRedirect should have comment or be unexported
internal/testutils/common.go:426:1: exported function GetGHData should have comment or be unexported
internal/testutils/common.go:621:1: exported function OpenShiftIdle should have comment or be unexported
internal/testutils/common.go:632:1: exported function OpenShiftDataRoute should have comment or be unexported
internal/util/osio_token.go:34:6: exported type Result should have comment or be unexported
internal/util/osio_token.go:38:6: exported type TokenResult should have comment or be unexported
internal/util/osio_token.go:43:6: exported type Token should have comment or be unexported

```

Doubt: main.go createAPIRouter() creates proxy API and router for it. What does createProxyRouter do then?

Fixes #171 and #190 