### PR TITLE
Issue #239 Adds retry operation for getUser call

### DIFF
--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -90,10 +90,10 @@ func main() {
 	}
 	mainLogger.WithField("clusters", clusters).Info("Retrieved cluster view")
 
-	start(config, &tenant, &wit, idler, store, clusters)
+	start(config, &tenant, wit, idler, store, clusters)
 }
 
-func start(config configuration.Configuration, tenant *clients.Tenant, wit *clients.WIT, idler clients.IdlerService, store storage.Store, clusters map[string]string) {
+func start(config configuration.Configuration, tenant *clients.Tenant, wit clients.WIT, idler clients.IdlerService, store storage.Store, clusters map[string]string) {
 	proxy, err := proxy.NewProxy(tenant, wit, idler, store, config, clusters)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/fabric8-jenkins-proxy/main_test.go
+++ b/cmd/fabric8-jenkins-proxy/main_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"io/ioutil"
+	"strconv"
+
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/storage"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/testutils"
@@ -16,8 +19,6 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/ory-am/dockertest.v3"
-	"io/ioutil"
-	"strconv"
 )
 
 var (
@@ -110,7 +111,7 @@ func TestProxy(t *testing.T) {
 
 	clusters := make(map[string]string)
 	clusters["https://api.free-stg.openshift.com/"] = "1b7d.free-stg.openshiftapps.com"
-	start(&mockConfig, &tenant, &wit, idler, store, clusters)
+	start(&mockConfig, &tenant, wit, idler, store, clusters)
 
 	// TODO - Test an actual workflow by triggering some of the MockURLs
 

--- a/internal/clients/wit.go
+++ b/internal/clients/wit.go
@@ -10,7 +10,11 @@ import (
 )
 
 // WIT describes work item tracker service of OSIO.
-type WIT struct {
+type WIT interface {
+	SearchCodebase(repo string) (*WITInfo, error)
+}
+
+type wit struct {
 	witURL    string
 	authToken string
 	client    *http.Client
@@ -18,7 +22,7 @@ type WIT struct {
 
 // NewWIT creates an instance of WIT client.
 func NewWIT(url string, token string) WIT {
-	return WIT{
+	return &wit{
 		witURL:    url,
 		authToken: token,
 		client:    &http.Client{},
@@ -80,7 +84,7 @@ func (wi *WITInfo) UnmarshalJSON(b []byte) (err error) {
 }
 
 // SearchCodebase finds and returns owner of a given repository based on URL.
-func (w WIT) SearchCodebase(repo string) (*WITInfo, error) {
+func (w *wit) SearchCodebase(repo string) (*WITInfo, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/search/codebases", w.witURL), nil)
 	if err != nil {
 		return nil, err

--- a/internal/metric/recorder.go
+++ b/internal/metric/recorder.go
@@ -15,7 +15,7 @@ func (pr PrometheusRecorder) Initialize() {
 	registerMetrics()
 }
 
-// RecordReqByTypeCounter records a request type
+// RecordReqByTypeTotal records a request type
 func (pr PrometheusRecorder) RecordReqByTypeTotal(requestType string) {
 	reportRequestsTotal(requestType)
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -585,14 +585,12 @@ func (p *Proxy) createRequestHash(url string, headers string) uint32 {
 }
 
 func (p *Proxy) getUserWithRetry(repositoryCloneURL string, logEntry *log.Entry, retry int) (clients.Namespace, error) {
-	var namespace clients.Namespace
-	var error error
 
 	for i := 0; i < retry; i++ {
-		namespace, error = p.getUser(repositoryCloneURL, logEntry)
+		namespace, err := p.getUser(repositoryCloneURL, logEntry)
 
-		if error == nil {
-			return namespace, error
+		if err == nil {
+			return namespace, err
 		}
 
 		time.Sleep(1000 * time.Millisecond)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,44 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"errors"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+	cache "github.com/patrickmn/go-cache"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockWit struct {
+	testCounter int // we will use this to count how many times this we get there
+}
+
+func (mw *mockWit) SearchCodebase(repo string) (*clients.WITInfo, error) {
+	mw.testCounter++
+	return &clients.WITInfo{
+		OwnedBy: "Faker",
+	}, errors.New("Reterror")
+}
+
+type fakeProxy struct {
+	Proxy
+}
+
+func TestGetUserWithRetry(t *testing.T) {
+	wit := &mockWit{testCounter: 0}
+
+	p := &fakeProxy{}
+	p.wit = wit
+	numberofretry := 1
+
+	logEntry := log.WithFields(log.Fields{"component": "proxy"})
+	cache := cache.New(2*time.Millisecond, 1*time.Millisecond)
+	p.TenantCache = cache
+
+	_, err := p.getUserWithRetry("http://test", logEntry, numberofretry)
+	assert.Error(t, err, "Faker")
+	assert.Equal(t, numberofretry+1, wit.testCounter)
+}


### PR DESCRIPTION
This commit adds a retry to getUser operation because it has been detected some sync issues between jenkins-proxy and wit.

The issue was originally opened at https://github.com/openshiftio/openshift.io/issues/3252