### PR TITLE
Issue #249 Make Redirection to Auth Temporary

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -360,7 +360,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, r
 	if needsAuth {
 		redirAuth := GetAuthURI(p.authURL, redirectURL.String())
 		requestLogEntry.Infof("Redirecting to auth: %s", redirAuth)
-		http.Redirect(w, r, redirAuth, 301)
+		http.Redirect(w, r, redirAuth, http.StatusTemporaryRedirect)
 	}
 	return
 }

--- a/internal/testutils/common.go
+++ b/internal/testutils/common.go
@@ -32,7 +32,7 @@ func MockRedirect(url string) *httptest.Server {
 		}
 		if redir, ok := req.URL.Query()["redirect"]; ok {
 			log.Info(fmt.Sprintf("MockRedirect to %s/toke-info...", redir[0]))
-			http.Redirect(w, req, fmt.Sprintf("%s%s", redir[0], AuthData1()), 301)
+			http.Redirect(w, req, fmt.Sprintf("%s%s", redir[0], AuthData1()), http.StatusTemporaryRedirect)
 			return
 		}
 	}))


### PR DESCRIPTION
Right now redirection to Auth for login is permanent (301).
Since permanent redirects are prolematic and might create a link
instead of directly redirecting. This should be changed to temporary
redirection(307), which is what this commit does.

Fixes #249