### PR TITLE
Issue #3356 Serve not-UI and not-GitHub request

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -218,6 +218,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, r
 	//If the user provides OSO token, we can directly proxy
 	if _, ok := r.Header["Authorization"]; ok { //FIXME Do we need this?
 		needsAuth = false
+		noProxy = false
 	}
 
 	if tj, ok := r.URL.Query()["token_json"]; ok { //If there is token_json in query, process it, find user info and login to Jenkins


### PR DESCRIPTION
Do not merge this PR blindly!
It has not been tested!

I just looked at the code and I think this is the reason of why https://github.com/fabric8-launcher/launcher-backend/pull/387 (which is reverted now) didn't fixed the problem with promote button - https://github.com/openshiftio/openshift.io/issues/3356

The Jenkins Proxy just ignores not-UI and not-GitHub requests (if I don't miss anything else here).