### PR TITLE
Issue #263 Make proxy local development ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ scripts/config
 
 # Misc
 .virtualgo
+*.key
+*.crt

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ Services running as a part of this local setup:
   - idler on 9001
   - tenant service on 9002
   - postgres on 5432
-  
+
+This will run proxy over HTTPS on port 8080.
+
 <a id="testing-webhooks"></a>
 ## Testing webhooks
 
@@ -160,7 +162,7 @@ There you can see the recent deliveries.
 Copy the payload of a webhook delivery into a file `webhook-payload.json`.
 Then execute the following curl command:
 
-    $ curl http://localhost:8080/github-webhook/ \
+    $ curl https://localhost:8080/github-webhook/ \
     -H "Content-Type: application/json" \
     -H "User-Agent: GitHub-Hookshot/c494ff1" \
     -H "X-GitHub-Event: status" \
@@ -172,7 +174,7 @@ Then execute the following curl command:
 
 Any request that is made to proxy(i.e., port 8080) regardless of the path, proxy will send a request to idler to unidle jenkins, if it is idled.
 
-    curl http://localhost:8080/*
+    curl https://localhost:8080/*
 
 This would show a spinning wheel until jenkins is idle. On running locally the html page might not exist so, it will show a message on not finding the html page.
 
@@ -182,7 +184,7 @@ This would show a spinning wheel until jenkins is idle. On running locally the h
 This project opens two ports 9091 and 8080. Proxy runs on 8080 and API router runs 9091. 
 The API router has only one API, which is info API. An example is as follows
 
-    Request: GET http://localhost:9091/api/info/ksagathi-preview
+    Request: GET https://localhost:9091/api/info/ksagathi-preview
 
     Response: {"namespace":"ksagathi-preview","requests":0,"last_visit":0,"last_request":0}
     

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -62,6 +62,9 @@ type Configuration interface {
 	// GetDebugMode returns if debug mode should be enabled as set via default, config file, or environment variable
 	GetDebugMode() bool
 
+	// GetHTTPSEnabled returns if https should be enabled as set via default, config file, or environment variable
+	GetHTTPSEnabled() bool
+
 	// String returns a string representation of the configuration
 	String() string
 }

--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -20,6 +20,7 @@ const (
 	defaultIndexPath                 = "/opt/fabric8-jenkins-proxy/index.html"
 	defaultMaxRequestRetry           = "10"
 	defaultDebugMode                 = "false"
+	defaultHTTPSEnabled              = "false"
 )
 
 var (
@@ -52,6 +53,7 @@ func init() {
 	settings["GetIndexPath"] = Setting{"JC_INDEX_PATH", defaultIndexPath, []func(interface{}, string) error{util.IsNotEmpty}}
 	settings["GetMaxRequestRetry"] = Setting{"JC_MAX_REQUEST_RETRY", defaultMaxRequestRetry, []func(interface{}, string) error{util.IsInt}}
 	settings["GetDebugMode"] = Setting{"JC_DEBUG_MODE", defaultDebugMode, []func(interface{}, string) error{util.IsBool}}
+	settings["GetHTTPSEnabled"] = Setting{"JC_ENABLE_HTTPS", defaultHTTPSEnabled, []func(interface{}, string) error{util.IsBool}}
 }
 
 // Setting is an element in the proxy configuration. It contains the environment
@@ -237,6 +239,15 @@ func (c *EnvConfig) GetMaxRequestRetry() int {
 
 // GetDebugMode returns if debug mode should be enabled as set via default, config file, or environment variable.
 func (c *EnvConfig) GetDebugMode() bool {
+	callPtr, _, _, _ := runtime.Caller(0)
+	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
+
+	b, _ := strconv.ParseBool(value)
+	return b
+}
+
+// GetHTTPSEnabled returns if https should be enabled as set via default, config file, or environment variable.
+func (c *EnvConfig) GetHTTPSEnabled() bool {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
 

--- a/internal/testutils/mock/mock_config.go
+++ b/internal/testutils/mock/mock_config.go
@@ -21,6 +21,7 @@ type Config struct {
 	IndexPath                 string
 	MaxRequestRetry           int
 	DebugMode                 bool
+	HTTPSEnabled              bool
 	Clusters                  map[string]string
 }
 
@@ -142,6 +143,11 @@ func (c *Config) GetMaxRequestRetry() int {
 // GetDebugMode return hardcoded debug mode from test configuration.
 func (c *Config) GetDebugMode() bool {
 	return c.DebugMode
+}
+
+// GetHTTPSEnabled return hardcoded http-enabled from test configuration.
+func (c *Config) GetHTTPSEnabled() bool {
+	return c.HTTPSEnabled
 }
 
 func (c *Config) String() string {

--- a/scripts/setupLocalProxy.sh
+++ b/scripts/setupLocalProxy.sh
@@ -67,6 +67,13 @@ login() {
     loc login https://api.rh-idev.openshift.com -n dsaas-preview --token=${DSAAS_PREVIEW_TOKEN} >/dev/null
 }
 
+generateCertificates() {
+    # generate only if needed
+    [[ -r server.key ]] && [[ -r server.crt ]] && return
+
+    openssl req -newkey rsa:2048 -nodes -keyout ./server.key -x509 -days 365 -out ./server.crt
+}
+
 ###############################################################################
 # Retrieves the required Auth token
 # Globals:
@@ -176,6 +183,7 @@ runPostgres() {
 start() {
     [ -z "${DSAAS_PREVIEW_TOKEN}" ] && echo "DSAAS_PREVIEW_TOKEN needs to be exported." && printHelp && exit 1
 
+    generateCertificates
     login
 
     loc get pods > /dev/null
@@ -203,7 +211,8 @@ env() {
 
     echo export JC_KEYCLOAK_URL=https://sso.prod-preview.openshift.io
     echo export JC_WIT_API_URL=https://api.prod-preview.openshift.io
-    echo export JC_REDIRECT_URL=http://localhost:8080
+    echo export JC_REDIRECT_URL=https://localhost:8080
+    echo export JC_ENABLE_HTTPS=true
     echo export JC_AUTH_URL=https://auth.prod-preview.openshift.io
     echo export JC_POSTGRES_PORT=${LOCAL_POSTGRES_PORT}
     echo export JC_POSTGRES_HOST=localhost
@@ -230,6 +239,7 @@ unsetEnv() {
     echo unset JC_KEYCLOAK_URL
     echo unset JC_WIT_API_URL
     echo unset JC_REDIRECT_URL
+    echo unset JC_ENABLE_HTTPS
     echo unset JC_AUTH_URL
     echo unset JC_POSTGRES_PORT
     echo unset JC_POSTGRES_HOST


### PR DESCRIPTION
Proxy runs only on secured host. Thus, for running proxy locally we
need to make localhost:8080 SSL enabled. This commit makes that process
easier.

Fixes #263 