### PR TITLE
Issue #267 Write Jenkins status API on a new server

### DIFF
--- a/internal/clients/tenant_test.go
+++ b/internal/clients/tenant_test.go
@@ -17,7 +17,7 @@ func TestGetTenant(t *testing.T) {
 		t.Error(err)
 	}
 
-	n, err := ct.GetNamespaceByType(ti, "jenkins")
+	n, err := GetNamespaceByType(ti, "jenkins")
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/jenkinsapi/jenkinsapi.go
+++ b/internal/jenkinsapi/jenkinsapi.go
@@ -1,0 +1,117 @@
+package jenkinsapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/configuration"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy"
+	log "github.com/sirupsen/logrus"
+)
+
+//JenkinsAPI contains API to check whether Jenkins for the current user is idle|running|starting
+type JenkinsAPI interface {
+	Start(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
+}
+
+// JenkinsAPIImpl implements JenkinsAPI
+type jenkinsAPIImpl struct {
+	tenant *clients.Tenant
+	idler  clients.IdlerService
+}
+
+// NewJenkinsAPI creates a new instance of JenkinsAPI
+func NewJenkinsAPI(tenant *clients.Tenant, idler clients.IdlerService) JenkinsAPI {
+	return &jenkinsAPIImpl{
+		tenant: tenant,
+		idler:  idler,
+	}
+}
+
+// Start returns the Jenkins status for the current user
+func (api *jenkinsAPIImpl) Start(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	resp := clients.StatusResponse{}
+
+	log.Infof("Status API ran")
+	tokenJSON, ok := r.URL.Query()["token_json"]
+	if !ok {
+		err := errors.New("Couldn't find token_json in the query")
+		handleError(w, resp, err, http.StatusBadRequest)
+		return
+	}
+	namespace, err := getNamespace(tokenJSON[0], api.tenant)
+	if err != nil {
+		handleError(w, resp, err, http.StatusInternalServerError)
+		return
+	}
+	log.Infof("Found token info in the query. Namespace is %s and clusterURL is %s", namespace.Name, namespace.ClusterURL)
+
+	status, err := api.idler.State(namespace.Name, namespace.ClusterURL)
+	if err != nil {
+		handleError(w, resp, err, http.StatusInternalServerError)
+		return
+	}
+	resp.Data = &clients.JenkinsInfo{
+		State: status,
+	}
+
+	if status != clients.Running {
+		httpCode, err := api.idler.UnIdle(namespace.Name, namespace.ClusterURL)
+		if err != nil {
+			handleError(w, resp, err, httpCode)
+			return
+		}
+		w.WriteHeader(httpCode)
+	}
+
+	json.NewEncoder(w).Encode(resp)
+
+}
+
+func handleError(w http.ResponseWriter, resp clients.StatusResponse, err error, httpCode int) {
+	log.Error(err)
+	w.WriteHeader(httpCode)
+	respErr := clients.ResponseError{
+		Code:        clients.ErrorCode(httpCode),
+		Description: err.Error(),
+	}
+	resp.Errors = append(resp.Errors, respErr)
+	json.NewEncoder(w).Encode(resp)
+}
+
+func getNamespace(tokenData string, tenant *clients.Tenant) (*clients.Namespace, error) {
+	tokenJSON := &proxy.TokenJSON{}
+	err := json.Unmarshal([]byte(tokenData), tokenJSON)
+	if err != nil {
+		return nil, err
+	}
+	config, err := configuration.NewConfiguration()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	publicKey, err := proxy.GetPublicKey(config.GetKeycloakURL())
+	if err != nil {
+		return nil, err
+	}
+
+	uid, err := proxy.GetTokenUID(tokenJSON.AccessToken, publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	ti, err := tenant.GetTenantInfo(uid)
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := tenant.GetNamespaceByType(ti, "jenkins")
+	if err != nil {
+		return nil, err
+	}
+
+	return &namespace, nil
+}

--- a/internal/jenkinsapi/jenkinsapi_test.go
+++ b/internal/jenkinsapi/jenkinsapi_test.go
@@ -1,0 +1,47 @@
+package jenkinsapi_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/jenkinsapi"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/testutils/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Start(t *testing.T) {
+	tenant, idler := setupDependencyServices()
+	jenkinsAPI := jenkinsapi.NewJenkinsAPI(tenant, idler)
+
+	r := httptest.NewRequest("GET", "/doesntmatter", nil)
+	r.Header.Set("Authorization", "Bearer InvalidToken")
+	w := httptest.NewRecorder()
+	jenkinsAPI.Start(w, r, nil)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	r = httptest.NewRequest("GET", "/doesntmatter", nil)
+	r.Header.Set("Authorization", "Bearer ValidToken")
+	w = httptest.NewRecorder()
+	jenkinsAPI.Start(w, r, nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+	fmt.Printf(w.Body.String())
+	assert.Equal(t, "{\"data\":{\"state\":\""+string(idler.IdlerState)+"\"}}\n", w.Body.String())
+}
+
+func setupDependencyServices() (clients.TenantService, *mock.Idler) {
+	configuration := mock.NewConfig()
+
+	configuration.IdlerURL = "doesnt_matter"
+
+	// Create tenant client
+	tenant := mock.Tenant{}
+
+	// Create Idler client
+	idler := mock.NewMockIdler(configuration.IdlerURL, clients.PodState("idled"))
+
+	return &tenant, idler
+}

--- a/internal/proxy/github.go
+++ b/internal/proxy/github.go
@@ -252,7 +252,7 @@ func (p *Proxy) getUser(repositoryCloneURL string, logEntry *log.Entry) (clients
 		return clients.Namespace{}, err
 	}
 
-	n, err := p.tenant.GetNamespaceByType(ti, ServiceName)
+	n, err := clients.GetNamespaceByType(ti, ServiceName)
 	if err != nil {
 		return clients.Namespace{}, err
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/configuration"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/metric"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/storage"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/util"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/util/logging"
 	"github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
@@ -55,17 +56,6 @@ type Proxy struct {
 	clusters        map[string]string
 }
 
-// Error represents list of error informations.
-type Error struct {
-	Errors []ErrorInfo
-}
-
-// ErrorInfo describes an HTTP error, consisting of HTTP status code and error detail.
-type ErrorInfo struct {
-	Code   string `json:"code"`
-	Detail string `json:"detail"`
-}
-
 // NewProxy creates an instance of Proxy client
 func NewProxy(
 	tenant *clients.Tenant, wit clients.WIT, idler clients.IdlerService,
@@ -93,7 +83,7 @@ func NewProxy(
 	Recorder.Initialize()
 
 	//Collect and parse public key from Keycloak
-	pk, err := GetPublicKey(config.GetKeycloakURL())
+	pk, err := util.GetPublicKey(config.GetKeycloakURL())
 	if err != nil {
 		return p, err
 	}

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -3,10 +3,12 @@ package proxy
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"html/template"
 	"net/http"
 	"runtime"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/util"
+	log "github.com/sirupsen/logrus"
 )
 
 //HandleError creates a JSON response with a given error and writes it to ResponseWriter
@@ -28,12 +30,12 @@ func (p *Proxy) HandleError(w http.ResponseWriter, err error, requestLogEntry *l
 	// create error response
 	w.WriteHeader(http.StatusInternalServerError)
 
-	pei := ErrorInfo{
+	pei := util.ErrorInfo{
 		Code:   fmt.Sprintf("%d", http.StatusInternalServerError),
 		Detail: err.Error(),
 	}
-	e := Error{
-		Errors: make([]ErrorInfo, 1),
+	e := util.Error{
+		Errors: make([]util.ErrorInfo, 1),
 	}
 	e.Errors[0] = pei
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/api"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/jenkinsapi"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy"
 	"github.com/julienschmidt/httprouter"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -16,6 +17,14 @@ func CreateAPIRouter(api api.ProxyAPI) *httprouter.Router {
 	proxyRouter.GET("/api/info/:namespace", api.Info)
 	proxyRouter.Handler("GET", "/metrics", promhttp.Handler())
 	return proxyRouter
+}
+
+// CreateJenkinsAPIRouter is creating a router for the REST API of the Proxy.
+func CreateJenkinsAPIRouter(jenkinsAPI jenkinsapi.JenkinsAPI) *httprouter.Router {
+	// Create router for API
+	jenkinsAPIRouter := httprouter.New()
+	jenkinsAPIRouter.GET("/api/jenkins/start", jenkinsAPI.Start)
+	return jenkinsAPIRouter
 }
 
 // CreateProxyRouter is the HTTP server handler which handles the incoming webhook and UI requests.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -23,7 +23,7 @@ func CreateAPIRouter(api api.ProxyAPI) *httprouter.Router {
 func CreateJenkinsAPIRouter(jenkinsAPI jenkinsapi.JenkinsAPI) *httprouter.Router {
 	// Create router for API
 	jenkinsAPIRouter := httprouter.New()
-	jenkinsAPIRouter.GET("/api/jenkins/start", jenkinsAPI.Start)
+	jenkinsAPIRouter.POST("/api/jenkins/start", jenkinsAPI.Start)
 	return jenkinsAPIRouter
 }
 

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -2,9 +2,14 @@ package router
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/jenkinsapi"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/storage"
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/require"
@@ -43,7 +48,26 @@ func (i *mockProxyAPI) Info(w http.ResponseWriter, r *http.Request, ps httproute
 	w.WriteHeader(http.StatusOK)
 }
 
-func Test_all_routes_are_setup(t *testing.T) {
+type mockJenkinsAPI struct{}
+
+// Start mock returns the Jenkins status for the current user
+func (api *mockJenkinsAPI) Start(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	resp := clients.StatusResponse{}
+
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		jenkinsapi.HandleError(w, resp, errors.New("Could not find Bearer Token in Authorization Header"), http.StatusUnauthorized)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	resp.Data = &clients.JenkinsInfo{
+		State: clients.UnknownState,
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func Test_API_routes_are_setup(t *testing.T) {
 	mockedProxyAPI := &mockProxyAPI{}
 	mockedRouter := CreateAPIRouter(mockedProxyAPI)
 	req, _ := http.NewRequest("GET", "/api/info/:namespace", nil)
@@ -55,4 +79,14 @@ func Test_all_routes_are_setup(t *testing.T) {
 	w = new(mockResponseWriter)
 	mockedRouter.ServeHTTP(w, req)
 	require.Contains(t, w.GetBody(), "go_gc_duration_seconds", "Routing failed for /metrics")
+}
+
+func Test_JenkinsAPI_routes_are_setup(t *testing.T) {
+	mockedJenkinsAPI := &mockJenkinsAPI{}
+	mockedRouter := CreateJenkinsAPIRouter(mockedJenkinsAPI)
+	req, _ := http.NewRequest("POST", "/api/jenkins/start", nil)
+	req.Header.Add("Authorization", "Bearer DoesntMatter")
+	w := new(mockResponseWriter)
+	mockedRouter.ServeHTTP(w, req)
+	require.Equal(t, "{\"data\":{\"state\":\"\"}}\n", w.GetBody(), "Routing failed for /api/jenkins/start")
 }

--- a/internal/testutils/mock/mock_idler.go
+++ b/internal/testutils/mock/mock_idler.go
@@ -1,0 +1,46 @@
+package mock
+
+import (
+	"errors"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+)
+
+// Idler is a mock implementation of idler service
+type Idler struct {
+	idlerAPI   string
+	IdlerState clients.PodState
+}
+
+// NewMockIdler is a constructor for mock.Idler
+func NewMockIdler(idlerAPI string, state clients.PodState) (idler *Idler) {
+	return &Idler{
+		idlerAPI:   idlerAPI,
+		IdlerState: state,
+	}
+}
+
+// State just returns the value set in Idler.state
+func (i *Idler) State(tenant string, openShiftAPIURL string) (clients.PodState, error) {
+	if openShiftAPIURL == "Valid_OpenShift_API_URL" {
+		return i.IdlerState, nil
+	}
+
+	return clients.UnknownState, errors.New("Invalid API URL")
+}
+
+// UnIdle always unidles (mock)
+func (i *Idler) UnIdle(tenant string, openShiftAPIURL string) (int, error) {
+	return 200, nil
+}
+
+// Clusters returns a map which maps the OpenShift API URL to the application DNS for this cluster. An empty map together with
+// an error is returned if an error occurs.
+func (i *Idler) Clusters() (map[string]string, error) {
+	clusters := map[string]string{
+		"https://api.free-stg.openshift.com/":           "1b7d.free-stg.openshiftapps.com",
+		"https://api.starter-us-east-2a.openshift.com/": "b542.starter-us-east-2a.openshiftapps.com",
+	}
+
+	return clusters, nil
+}

--- a/internal/testutils/mock/mock_tenant.go
+++ b/internal/testutils/mock/mock_tenant.go
@@ -1,0 +1,32 @@
+package mock
+
+import (
+	"errors"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+)
+
+// Tenant is a simple client for fabric8-tenant.
+type Tenant struct {
+}
+
+// GetTenantInfo returns a tenant information based on tenant id.
+func (t Tenant) GetTenantInfo(tenantID string) (ti clients.TenantInfo, err error) {
+	return
+}
+
+// GetNamespace mock gets namespace
+func (t Tenant) GetNamespace(accessToken string) (namespace clients.Namespace, err error) {
+	if accessToken == "ValidToken" {
+		namespace = clients.Namespace{
+			ClusterURL: "Valid_OpenShift_API_URL",
+			Name:       "namespace-jenkins",
+			State:      "",
+			Type:       "jenkins",
+		}
+		return
+	}
+
+	err = errors.New("Invalid Token")
+	return
+}

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -1,0 +1,12 @@
+package util
+
+// Error represents list of error informations.
+type Error struct {
+	Errors []ErrorInfo
+}
+
+// ErrorInfo describes an HTTP error, consisting of HTTP status code and error detail.
+type ErrorInfo struct {
+	Code   string `json:"code"`
+	Detail string `json:"detail"`
+}

--- a/internal/util/token.go
+++ b/internal/util/token.go
@@ -1,4 +1,4 @@
-package proxy
+package util
 
 import (
 	"crypto/rsa"


### PR DESCRIPTION
This commit creates a new server on :9092 and add an API at
`/api/status`, which would return current status of jenkinns and
trigger it unidling when the user's token_json(OSIO token) passed in
the query
```
Request: https://localhost:9092/api/status?token_json=$TOKEN_JSON
Response: { status: idled|starting|running }
```
Tested this to be working locally. 
@chmouel @sthaha Let me know if current approach look good to you. If so, I will move toward writing tests for this.

Part of https://github.com/openshiftio/openshift.io/issues/3356
Fixes #267 