### PR TITLE
Fix #278 Implement a requestid identifier to correlate queries

### DIFF
--- a/internal/clients/idler_test.go
+++ b/internal/clients/idler_test.go
@@ -1,0 +1,15 @@
+package clients
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRequest(t *testing.T) {
+	req, _ := newRequest("http://blah")
+	assert.NotEmpty(t, req.Header.Get("X-Request-ID"), "X-Request-ID wasn't generated")
+
+	_, err := newRequest("blah://foo\\/\\/bar")
+	assert.Error(t, err, "Should have generated a URL error")
+}


### PR DESCRIPTION
Let's use this to pass to idler so we can correlate the action between idler and
proxy.

We change the logging facility from Debug to Info for the Idle/Unidle but leave
it as Debug for State so we don't fill up too much the logs with noise.

Only testing was added for the new function. Writting tests for the whole
clients would need quite a bit of refactoring to use intefaces.