### PR TITLE
Fix #280 Unidle Jenkins only if needed

### DIFF
--- a/static/html/index.html
+++ b/static/html/index.html
@@ -55,7 +55,10 @@
           });
         }
 
-        check()
+        // don't start immediately as the page is returned only if
+        // jenkins is idled and we assume that it won't be unidled
+        // as soon as the page is returned
+        setTimeout(check, timeout)
       });
     </script>
 </head>


### PR DESCRIPTION
This patch refactors un-idling to proxy's startJenkins function
which unildes jenkins only if it the state is "idled"