### PR TITLE
Fix #284 Prunes outdated cookies

### DIFF
--- a/internal/proxy/cookies.go
+++ b/internal/proxy/cookies.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	"github.com/satori/go.uuid"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// CookieJenkinsIdled stores name of the cookie through which we can check if service is idled
+	CookieJenkinsIdled = "JenkinsIdled"
+
+	// SessionCookie stores name of the session cookie of the service in question
+	SessionCookie = "JSESSIONID"
+)
+
+type cookieFilterFn func(cookie *http.Cookie) bool
+
+func cookieNames(cookies []*http.Cookie) []string {
+	names := []string{}
+	for _, cookie := range cookies {
+		names = append(names, cookie.Name)
+	}
+	return names
+}
+
+func expireCookiesMatching(w http.ResponseWriter, r *http.Request, expire cookieFilterFn) {
+	for _, cookie := range r.Cookies() {
+		if expire(cookie) {
+			expireCookie(w, cookie)
+		}
+		http.SetCookie(w, cookie)
+	}
+}
+
+func expireCookie(w http.ResponseWriter, c *http.Cookie) {
+	c.Expires = time.Unix(0, 0)
+	http.SetCookie(w, c)
+}
+
+func isSessionCookie(c *http.Cookie) bool {
+	return strings.HasPrefix(c.Name, SessionCookie)
+}
+
+func isIdledCookie(c *http.Cookie) bool {
+	return c.Name == CookieJenkinsIdled
+}
+
+func isSessionOrIdledCookie(c *http.Cookie) bool {
+	return isSessionCookie(c) || isIdledCookie(c)
+}
+
+func anyCookie(_ *http.Cookie) bool {
+	return true
+}
+
+func setIdledCookie(w http.ResponseWriter) string {
+	c := &http.Cookie{}
+	c.Name = CookieJenkinsIdled
+	c.Value = uuid.NewV4().String()
+	http.SetCookie(w, c)
+	return c.Value
+}
+
+// set all cookies to w and returns the session cookie if it exists
+func setJenkinsCookies(w http.ResponseWriter, cookies []*http.Cookie) *http.Cookie {
+	var jsessionCookie *http.Cookie
+
+	for _, cookie := range cookies {
+		http.SetCookie(w, cookie)
+		if isSessionCookie(cookie) {
+			jsessionCookie = cookie
+		}
+	}
+	return jsessionCookie
+}

--- a/internal/proxy/github.go
+++ b/internal/proxy/github.go
@@ -32,8 +32,8 @@ type GHHookStruct struct {
 	} `json:"repository"`
 }
 
-func (p *Proxy) handleGitHubRequest(w http.ResponseWriter, r *http.Request, requestLogEntry *log.Entry) (ns string, noProxy bool) {
-	noProxy = true
+func (p *Proxy) handleGitHubRequest(w http.ResponseWriter, r *http.Request, requestLogEntry *log.Entry) (ns string, okToForward bool) {
+	okToForward = false
 	//Load request body if it's GH webhook
 	gh := GHHookStruct{}
 	defer r.Body.Close()
@@ -86,7 +86,7 @@ func (p *Proxy) handleGitHubRequest(w http.ResponseWriter, r *http.Request, requ
 		return
 	}
 
-	noProxy = false
+	okToForward = true
 	r.Body = ioutil.NopCloser(bytes.NewReader(body))
 	//If Jenkins is up, we can simply proxy through
 	requestLogEntry.WithField("ns", ns).Infof(fmt.Sprintf("Passing through %s", r.URL.String()))

--- a/internal/proxy/ui_requests.go
+++ b/internal/proxy/ui_requests.go
@@ -11,212 +11,275 @@ import (
 
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/util"
-	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	// CookieJenkinsIdled stores name of the cookie through which we can check if service is idled
-	CookieJenkinsIdled = "JenkinsIdled"
-	// ServiceName is name of service that we are trying to idle or unidle
-	ServiceName = "jenkins"
-	// SessionCookie stores name of the session cookie of the service in question
-	SessionCookie = "JSESSIONID"
-)
+func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, logger *log.Entry) (cacheKey, ns string, okToForward bool) {
+	logger.Infof("Incoming request: %s Cookies: %v ", r.URL.Path, cookieNames(r.Cookies()))
 
-func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, requestLogEntry *log.Entry) (cacheKey string, ns string, noProxy bool) {
-	//redirect determines if we need to redirect to auth service
-	needsAuth := true
-	noProxy = true
+	needsAuth := true   // indicates if we need to redirect to auth service
+	okToForward = false // indicates if its ready to forward requests to Jenkins
 
-	//redirectURL is used for auth service as a target of successful auth redirect
+	// redirectURL is used for auth service as a target of successful auth redirect
 	redirectURL, err := url.ParseRequestURI(fmt.Sprintf("%s%s", strings.TrimRight(p.redirect, "/"), r.URL.Path))
 	if err != nil {
-		p.HandleError(w, err, requestLogEntry)
+		p.HandleError(w, err, logger)
 		return
 	}
 
-	//If the user provides OSO token, we can directly proxy
-	if _, ok := r.Header["Authorization"]; ok { //FIXME Do we need this?
-		needsAuth = false
-	}
+	if tj, ok := r.URL.Query()["token_json"]; ok {
+		// If there is token_json in query, process it, find user info and login to Jenkins
+		tjLogger := logger.WithField("part", "token_json")
 
-	if tj, ok := r.URL.Query()["token_json"]; ok { //If there is token_json in query, process it, find user info and login to Jenkins
 		if len(tj) < 1 {
-			p.HandleError(w, errors.New("could not read JWT token from URL"), requestLogEntry)
+			p.HandleError(w, errors.New("could not read JWT token from URL"), tjLogger)
 			return
 		}
 
-		pci, osioToken, err := p.processToken([]byte(tj[0]), requestLogEntry)
+		pci, osioToken, err := p.processToken([]byte(tj[0]), tjLogger)
 		if err != nil {
-			p.HandleError(w, err, requestLogEntry)
+			p.HandleError(w, err, tjLogger)
 			return
 		}
+
 		ns = pci.NS
 		clusterURL := pci.ClusterURL
-		nsLogger := requestLogEntry.WithFields(log.Fields{"ns": ns, "cluster": clusterURL})
-		nsLogger.Debug("Found token info in query")
 
-		// we don't care about code here since only the state of jenkins pod
+		nsLogger := tjLogger.WithFields(log.Fields{"ns": ns, "cluster": clusterURL})
+		nsLogger.Infof("found ns : %q, cluster: %q", ns, clusterURL)
+
+		// we don't care about code here since only the state of jenkins pod -
 		// running or not is what is relevant
-
 		state, _, err := p.startJenkins(ns, clusterURL)
 		if err != nil {
-			p.HandleError(w, err, requestLogEntry)
+			p.HandleError(w, err, nsLogger)
 			return
 		}
 
 		if state != clients.Running {
 			// Break the process if Jenkins isn't running.
 
+			nsLogger.Infof("setting idled cookie: %v ", pci)
+
+			// jenkins is idled and there could be old jsession, so delete them as
+			// it will be invalid at this point
+			expireCookiesMatching(w, r, isSessionCookie)
+
 			// Set "idled" cookie to indicate that jenkins is idled
 			// also cache the ns & cluster for faster lookup next time
-			p.setIdledCookie(w, pci)
+			uuid := setIdledCookie(w)
+			p.ProxyCache.SetDefault(uuid, pci)
 
-			// Redirect to get rid of token in URL
+			// Redirect to set the idled cookied and to  get rid of token in URL
 			nsLogger.Info("Redirecting to remove token from URL")
 			http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 			return
 		}
 
-		// Jenkins is running at this point
+		// Jenkins is running at this point; login and set the jenkins cookies
 		osoToken, err := util.GetOSOToken(p.authURL, pci.ClusterURL, osioToken)
 		if err != nil {
-			p.HandleError(w, err, requestLogEntry)
+			p.HandleError(w, err, nsLogger)
 			return
 		}
-		requestLogEntry.WithField("ns", ns).Debug("Loaded OSO token")
+		nsLogger.Info("Fetched OSO token from OSIO token")
 
-		statusCode, cookies, err := p.loginJenkins(pci, osoToken, requestLogEntry)
+		status, jenkinsCookies, err := p.loginJenkins(pci, osoToken, nsLogger)
 		if err != nil {
-			p.HandleError(w, err, requestLogEntry)
+			p.HandleError(w, err, nsLogger)
 			return
 		}
-		if statusCode == http.StatusOK {
-			for _, cookie := range cookies {
-				if cookie.Name == CookieJenkinsIdled {
-					continue
-				}
-				http.SetCookie(w, cookie)
-				if strings.HasPrefix(cookie.Name, SessionCookie) { //Find session cookie and use it's value as a key for cache
-					p.ProxyCache.SetDefault(cookie.Value, pci)
-					requestLogEntry.WithField("ns", ns).Infof("Cached Jenkins route %s in %s", pci.Route, cookie.Value)
-					requestLogEntry.WithField("ns", ns).Infof("Redirecting to %s", redirectURL.String())
-					//If all good, redirect to self to remove token from url
-					http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+
+		nsLogger.Infof("Jenkins Login returned: %v", cookieNames(jenkinsCookies))
+
+		if status != http.StatusOK {
+			p.HandleError(w, fmt.Errorf("could not login to Jenkins in %q namespace", ns), nsLogger)
+			return
+		}
+
+		// there could be old session cookies, so lets clear it
+		expireCookiesMatching(w, r, isSessionOrIdledCookie)
+
+		// set all cookies that we got from jenkins
+		jsessionCookie := setJenkinsCookies(w, jenkinsCookies)
+		if jsessionCookie == nil {
+			// for some reason, login didn't return a session cookie
+			p.HandleError(w, fmt.Errorf("could not find cookie %q for %q", SessionCookie, ns), nsLogger)
+			return
+		}
+
+		// Update proxy-cache to associate pci with the session cookie
+		// the cache so that, the subsequent request that would contain the
+		// the jession cookie can be used to lookup the cache
+		p.ProxyCache.SetDefault(jsessionCookie.Value, pci)
+		nsLogger.Infof("Cached Jenkins route %q in %q", pci.Route, jsessionCookie.Value)
+
+		// If all good, redirect to self to remove token from url
+		nsLogger.Infof("Redirecting to %q", redirectURL)
+		http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+		return
+	}
+
+	if len(r.Cookies()) > 0 {
+		// Check cookies and proxy cache to find user info
+		cookieLogger := logger.WithField("part", "cookie")
+
+		for _, cookie := range r.Cookies() {
+
+			if !isSessionOrIdledCookie(cookie) {
+				continue // only the session and idled cookies are cached
+			}
+
+			cacheVal, ok := p.ProxyCache.Get(cookie.Value)
+			if !ok {
+				// if the cookie is not in cache, it could be an old idled or jsessionid
+				// cookie so lets clear it
+				cookieLogger.Infof("cookies: %q is session or idle is OLD; expiring", cookie.Name)
+				expireCookie(w, cookie)
+				continue
+			}
+
+			cacheKey = cookie.Value
+			pci := cacheVal.(CacheItem)
+			ns = pci.NS
+			clusterURL := pci.ClusterURL
+
+			nsLogger := log.WithFields(log.Fields{"ns": ns, "cluster": clusterURL, "cookie": cookie.Name})
+			nsLogger.Infof("cookie: %q is in cache", cookie.Name)
+
+			if isSessionCookie(cookie) {
+				// We found a session cookie in cache
+				scLogger := nsLogger.WithField("cookietype", "session")
+				scLogger.Infof("Cache has Jenkins route %q in %q", pci.Route, cookie.Value)
+
+				// ensure jenkins is running
+				state, _, err := p.startJenkins(ns, pci.ClusterURL)
+				if err != nil {
+					p.HandleError(w, err, scLogger)
 					return
 				}
 
-				//If we got here, the cookie was not found - report error
-				p.HandleError(w, fmt.Errorf("could not find cookie %s for %s", SessionCookie, pci.NS), requestLogEntry)
-			}
-		} else {
-			p.HandleError(w, fmt.Errorf("could not login to Jenkins in %s namespace", ns), requestLogEntry)
-		}
-	}
+				if state == clients.Running {
+					scLogger.Infof("jenkins is running | so rev proxy: %+v", pci)
 
-	if len(r.Cookies()) > 0 { //Check cookies and proxy cache to find user info
-		for _, cookie := range r.Cookies() {
-			cacheVal, ok := p.ProxyCache.Get(cookie.Value)
-			if !ok {
-				continue
+					needsAuth = false  // user is logged in; do not redirect
+					okToForward = true // good to be reverse-proxied
+					r.Host = pci.Route // Configure proxy upstream
+					r.URL.Host = pci.Route
+					r.URL.Scheme = pci.Scheme
+					return
+				}
+
+				// we find a session cookie in cache but the pod is not running
+				// so lets clear the cookie and the cache entry
+				p.ProxyCache.Delete(cacheKey)
+				cacheKey = "" // cacheKey isn't valid any more
+				expireCookiesMatching(w, r, isSessionOrIdledCookie)
+				p.recordStatistics(pci.NS, time.Now().Unix(), 0) //FIXME - maybe do this at the beginning?
+
+				break // and do a reauth
 			}
-			if strings.HasPrefix(cookie.Name, SessionCookie) {
-				// We found a session cookie in cache
-				cacheKey = cookie.Value
-				pci := cacheVal.(CacheItem)
-				r.Host = pci.Route //Configure proxy upstream
-				r.URL.Host = pci.Route
-				r.URL.Scheme = pci.Scheme
-				ns = pci.NS
-				needsAuth = false //user is probably logged in, do not redirect
-				noProxy = false
-				break
-			} else if cookie.Name == CookieJenkinsIdled {
-				// Found a cookie saying Jenkins is idled, verify and act accordingly
-				cacheKey = cookie.Value
+
+			if isIdledCookie(cookie) {
+				// Found a cookie saying Jenkins is idled
+				icLogger := nsLogger.WithField("cookietype", "idle")
+				icLogger.Infof("Cache has Jenkins route %q in %q", pci.Route, cookie.Value)
+
 				needsAuth = false
-				pci := cacheVal.(CacheItem)
-				ns = pci.NS
-				clusterURL := pci.ClusterURL
-
 				state, code, err := p.startJenkins(ns, clusterURL)
 				if err != nil {
-					p.HandleError(w, err, requestLogEntry)
+					p.HandleError(w, err, icLogger)
 					return
 				}
 
 				// error if unexpected code is returned
 				if code != http.StatusServiceUnavailable && code != http.StatusAccepted {
-					p.HandleError(w, fmt.Errorf("Failed to send unidle request using fabric8-jenkins-idler: code: %d", code), requestLogEntry)
+					err = fmt.Errorf("Failed to send unidle request using fabric8-jenkins-idler: code: %d", code)
+					p.HandleError(w, err, icLogger)
+					return
 				}
 
 				if state != clients.Running {
 					w.WriteHeader(code)
-					err = p.processTemplate(w, ns, requestLogEntry)
+					err = p.processTemplate(w, ns, icLogger)
 					if err != nil {
-						p.HandleError(w, err, requestLogEntry)
-						return
+						p.HandleError(w, err, icLogger)
 					}
-					p.recordStatistics(pci.NS, time.Now().Unix(), 0) //FIXME - maybe do this at the beginning?
-
-				} else {
-					// Jenkins is running, remove the idled cookie
-					// OpenShift can take up to couple tens of second to update HAProxy configuration for new route
-					// so even if the pod is up, route might still return 500 - i.e. we need to check the route
-					// before claiming Jenkins is up
-					var statusCode int
-					statusCode, _, err = p.loginJenkins(pci, "", requestLogEntry)
-					if err != nil {
-						p.HandleError(w, err, requestLogEntry)
-						return
-					}
-					if statusCode == 200 || statusCode == 403 {
-						cookie.Expires = time.Unix(0, 0)
-						http.SetCookie(w, cookie)
-					} else {
-						w.WriteHeader(http.StatusAccepted)
-						err = p.processTemplate(w, ns, requestLogEntry)
-						if err != nil {
-							p.HandleError(w, err, requestLogEntry)
-							return
-						}
-					}
+					p.recordStatistics(ns, time.Now().Unix(), 0) //FIXME - maybe do this at the beginning?
+					return
 				}
+
+				// Jenkins seems to be running but OpenShift can take up to couple of
+				// tens of second to update HAProxy configuration for new route
+				// so even if the pod is up, route might still return 500 - i.e.
+				// we need to check the route before claiming Jenkins is up
+
+				icLogger.Infof("check if login works: %v ", pci)
+
+				// login is performed using "" token to only verify if jenkins is actually running
+				var statusCode int
+				statusCode, _, err = p.loginJenkins(pci, "", icLogger)
 
 				if err != nil {
-					p.HandleError(w, err, requestLogEntry)
+					p.HandleError(w, err, icLogger)
+					return
 				}
-				break
+
+				if statusCode == http.StatusOK ||
+					statusCode == http.StatusForbidden {
+					icLogger.Infof("jenkins is running fine and returned %d", statusCode)
+
+					// jenkins is up and running; so expire both session and idled cookies
+					// so that the next request will end up in re-auth and thus try
+					// acutal login to Jenkins with the token_json which will then setup
+					// the jsession cookies
+
+					expireCookiesMatching(w, r, isSessionOrIdledCookie)
+					p.ProxyCache.Delete(cacheKey)
+					cacheKey = ""
+
+				} else {
+					icLogger.Infof("Jenkins isn't running yet so process template")
+					w.WriteHeader(http.StatusAccepted)
+					err = p.processTemplate(w, ns, icLogger)
+					if err != nil {
+						p.HandleError(w, err, icLogger)
+					}
+				}
 			}
 		}
-		if len(cacheKey) == 0 { //If we do not have user's info cached, run through login process to get it
-			requestLogEntry.WithField("ns", ns).Info("Could not find cache, redirecting to re-login")
+
+		// If we do not have user's info cached, run through login process to get it
+		if len(cacheKey) == 0 {
+			logger.WithField("ns", ns).Info("Could not find cache, redirecting to re-login")
 		} else {
-			requestLogEntry.WithField("ns", ns).Infof("Found cookie %s", cacheKey)
+			logger.WithField("ns", ns).Infof("Found cookie %s", cacheKey)
 		}
 	}
 
 	//Check if we need to redirect to auth service
 	if needsAuth {
 		redirAuth := util.GetAuthURI(p.authURL, redirectURL.String())
-		requestLogEntry.Infof("Redirecting to auth: %s", redirAuth)
+		logger.Infof("Redirecting to auth: %q", redirAuth)
 
+		// clear session and idle cookies as this is a fresh start
+		expireCookiesMatching(w, r, isSessionOrIdledCookie)
 		w.Header().Set("Cache-Control", "no-cache")
 		http.Redirect(w, r, redirAuth, http.StatusTemporaryRedirect)
 	}
 	return
 }
 
-func (p *Proxy) loginJenkins(pci CacheItem, osoToken string, requestLogEntry *log.Entry) (int, []*http.Cookie, error) {
+func (p *Proxy) loginJenkins(pci CacheItem, osoToken string, logger *log.Entry) (int, []*http.Cookie, error) {
 	//Login to Jenkins with OSO token to get cookies
 	jenkinsURL := fmt.Sprintf("%s://%s/securityRealm/commenceLogin?from=%%2F", pci.Scheme, pci.Route)
+
 	req, _ := http.NewRequest("GET", jenkinsURL, nil)
 	if len(osoToken) > 0 {
-		requestLogEntry.WithField("ns", pci.NS).Infof("Jenkins login for %s", jenkinsURL)
+		logger.WithField("ns", pci.NS).Infof("Jenkins login for %s", jenkinsURL)
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", osoToken))
 	} else {
-		requestLogEntry.WithField("ns", pci.NS).Infof("Accessing Jenkins route %s", jenkinsURL)
+		logger.WithField("ns", pci.NS).Infof("Accessing Jenkins route %s", jenkinsURL)
 	}
 	c := http.DefaultClient
 	resp, err := c.Do(req)
@@ -227,17 +290,7 @@ func (p *Proxy) loginJenkins(pci CacheItem, osoToken string, requestLogEntry *lo
 	return resp.StatusCode, resp.Cookies(), err
 }
 
-func (p *Proxy) setIdledCookie(w http.ResponseWriter, pci CacheItem) {
-	c := &http.Cookie{}
-	u1 := uuid.NewV4().String()
-	c.Name = CookieJenkinsIdled
-	c.Value = u1
-	p.ProxyCache.SetDefault(u1, pci)
-	http.SetCookie(w, c)
-	return
-}
-
-func (p *Proxy) processToken(tokenData []byte, requestLogEntry *log.Entry) (pci CacheItem, osioToken string, err error) {
+func (p *Proxy) processToken(tokenData []byte, logger *log.Entry) (pci CacheItem, osioToken string, err error) {
 	tokenJSON := &util.TokenJSON{}
 	err = json.Unmarshal(tokenData, tokenJSON)
 	if err != nil {
@@ -260,7 +313,7 @@ func (p *Proxy) processToken(tokenData []byte, requestLogEntry *log.Entry) (pci 
 		return
 	}
 
-	requestLogEntry.WithField("ns", namespace.Name).Debug("Extracted information from token")
+	logger.WithField("ns", namespace.Name).Debug("Extracted information from token")
 	route, scheme, err := p.constructRoute(namespace.ClusterURL, namespace.Name)
 	if err != nil {
 		return
@@ -277,19 +330,21 @@ func (p *Proxy) processToken(tokenData []byte, requestLogEntry *log.Entry) (pci 
 func (p *Proxy) startJenkins(ns, clusterURL string) (state clients.PodState, code int, err error) {
 	// Assume pods are starting and unidle only if it is in "idled" state
 	code = http.StatusAccepted
+	nsLogger := log.WithFields(log.Fields{"ns": ns, "cluster": clusterURL})
 
 	state, err = p.idler.State(ns, clusterURL)
 	if err != nil {
 		return
 	}
+	nsLogger.Infof("state : %q", state)
 
 	if state == clients.Idled {
 		// Unidle only if needed
+		nsLogger.Infof("Unidling jenkins")
 		if code, err = p.idler.UnIdle(ns, clusterURL); err != nil {
 			return
 		}
 	}
-
 	if code == http.StatusOK {
 		// XHR relies on 202 to retry and 200 to stop retrying and reload
 		// since we just started jenkins pods, change the code to 202 so

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -51,9 +51,15 @@ func (p *Proxy) processTemplate(w http.ResponseWriter, ns string, requestLogEntr
 	if err != nil {
 		return
 	}
-	data := struct{ Retry int }{Retry: 15}
+	// Jenkins takes around 4 mins to start so start with
+	// 2 min, 1 min, ...  until 15 sec
+	// see index.html that implements the exponential backoff retry
+	data := struct {
+		RetryMaxInterval int
+		RetryMinInterval int
+	}{2 * 60, 15}
+
 	requestLogEntry.WithField("ns", ns).Debug("Templating index.html")
 	err = tmplt.Execute(w, data)
-
 	return
 }

--- a/static/html/index.html
+++ b/static/html/index.html
@@ -18,12 +18,25 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script type="application/javascript">
       $(document).ready(function() {
-        var timeout = {{.Retry}}*1000
 
         function showStatus(header, body) {
           $("#header").text(header)
           $("#status").text(body)
         }
+
+        function expBackoffInterval(max, min) {
+          var current = max * 2
+          return function next() {
+            current = Math.max(current / 2, min)
+            return current
+          }
+        }
+
+        var retryMaxInterval = {{.RetryMaxInterval}} * 1000
+        var retryMinInterval = {{.RetryMinInterval}} * 1000
+
+        var nextInterval = expBackoffInterval(retryMaxInterval, retryMinInterval)
+
         function check() {
           console.log("Checking", window.location)
           $.ajax({
@@ -35,21 +48,21 @@
                 console.log("Got 200, reloading...")
                 showStatus("Starting Jenkins", "Jenkins is up and running; loading..." )
                 // wait a bit longer for jenkins to boot properly after idle
-                setTimeout(function(){ window.location.reload(true) }, timeout)
+                setTimeout(function(){ window.location.reload(true) }, retryMinInterval)
               },
               202: function(){
                 console.log("Got 202, waiting along..")
                 showStatus("Starting Jenkins", "Jenkins is currently idled. Please wait while we start it...")
-                setTimeout(check, timeout)
+                setTimeout(check, nextInterval())
               },
               503: function(){
                 console.log("Got 503, Cluster resources capacity is full. waiting along..")
                 showStatus("Failed to start Jenkins", "OpenShift cluster is experiencing heavy load. Retrying...")
-                setTimeout(check, timeout)
+                setTimeout(check, nextInterval())
               },
               default: function(xhr, status, e) {
                 console.error(status)
-                setTimeout(check, timeout)
+                setTimeout(check, nextInterval())
               }
             }
           });
@@ -58,7 +71,7 @@
         // don't start immediately as the page is returned only if
         // jenkins is idled and we assume that it won't be unidled
         // as soon as the page is returned
-        setTimeout(check, timeout)
+        setTimeout(check, nextInterval())
       });
     </script>
 </head>
@@ -66,7 +79,7 @@
   <div class="container">
     <h1 id="header"> Starting Jenkins ... </h1>
     <img src="https://upload.wikimedia.org/wikipedia/commons/b/b1/Loading_icon.gif" />
-    <p>Status: <span id="status"> please wait...</span> </p>
+    <p>Status: <span id="status"> starting; please wait...</span> </p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
The patch ensures that old and outdated cookies are pruned at
various stages of Jenkins UI request handling logic.

The patch also refactors the ui request handling part:
- move cookie handling to its own file
- improves logging by adding more details into the structured logs
- improves retry logic using exponential back off