### PR TITLE
[WIP] Issue #107 Allow for resetting the database

### DIFF
--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -78,6 +78,10 @@ func main() {
 
 	store := storage.NewDBStorage(db)
 
+	if config.GetResetDBFlag() {
+		store.Reset()
+	}
+
 	// Create tenant client
 	tenant := clients.NewTenant(config.GetTenantURL(), config.GetAuthToken())
 

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -65,6 +65,10 @@ type Configuration interface {
 	// GetHTTPSEnabled returns if https should be enabled as set via default, config file, or environment variable
 	GetHTTPSEnabled() bool
 
+	// GetResetDBFlag return true if we are supposed to reset the database according to the JC_RESET_DB_FLAG as set
+	// via default, config file, or environment variable.
+	GetResetDBFlag() bool
+
 	// String returns a string representation of the configuration
 	String() string
 }

--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -21,6 +21,7 @@ const (
 	defaultMaxRequestRetry           = "10"
 	defaultDebugMode                 = "false"
 	defaultHTTPSEnabled              = "false"
+	defaultResetDBFlag               = "false"
 )
 
 var (
@@ -54,6 +55,7 @@ func init() {
 	settings["GetMaxRequestRetry"] = Setting{"JC_MAX_REQUEST_RETRY", defaultMaxRequestRetry, []func(interface{}, string) error{util.IsInt}}
 	settings["GetDebugMode"] = Setting{"JC_DEBUG_MODE", defaultDebugMode, []func(interface{}, string) error{util.IsBool}}
 	settings["GetHTTPSEnabled"] = Setting{"JC_ENABLE_HTTPS", defaultHTTPSEnabled, []func(interface{}, string) error{util.IsBool}}
+	settings["GetResetDBFlag"] = Setting{"JC_RESET_DB_FLAG", defaultResetDBFlag, []func(interface{}, string) error{util.IsBool}}
 }
 
 // Setting is an element in the proxy configuration. It contains the environment
@@ -248,6 +250,16 @@ func (c *EnvConfig) GetDebugMode() bool {
 
 // GetHTTPSEnabled returns if https should be enabled as set via default, config file, or environment variable.
 func (c *EnvConfig) GetHTTPSEnabled() bool {
+	callPtr, _, _, _ := runtime.Caller(0)
+	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
+
+	b, _ := strconv.ParseBool(value)
+	return b
+}
+
+// GetResetDBFlag return true if we are supposed to reset the database according to the JC_RESET_DB_FLAG as set
+// via default, config file, or environment variable.
+func (c *EnvConfig) GetResetDBFlag() bool {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
 

--- a/internal/storage/db_store.go
+++ b/internal/storage/db_store.go
@@ -100,3 +100,19 @@ func (s *DBStore) LogStats() {
 func (s *DBStore) updateRequest(r *Request) error {
 	return s.db.Save(r).Error
 }
+
+// Reset deletes the database schema
+func (s *DBStore) Reset() {
+	s.db.Exec("DROP SCHEMA public CASCADE;CREATE SCHEMA public;GRANT ALL ON SCHEMA public TO postgres;GRANT ALL ON SCHEMA public TO public;")
+	dbLogger.Infof("Schema dropped, recreating again")
+
+	request := &Request{}
+	if !s.db.HasTable(request) {
+		s.db.CreateTable(request)
+	}
+
+	stats := &Statistics{}
+	if !s.db.HasTable(stats) {
+		s.db.CreateTable(stats)
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -30,6 +30,7 @@ type Store interface {
 	GetStatisticsUser(ns string) (o *Statistics, notFound bool, err error)
 
 	LogStats()
+	Reset()
 }
 
 // LogStorageStats enables logging of stogare statistics.

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -58,6 +58,10 @@ func (m *mockStore) LogStats() {
 	dbLogger.Info("mock db stats")
 }
 
+func (m *mockStore) Reset() {
+	dbLogger.Info("Namesake function, mock reset the database")
+}
+
 func Test_logging_of_store_stats(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	testLogger, hook := test.NewNullLogger()

--- a/internal/testutils/mock/mock_config.go
+++ b/internal/testutils/mock/mock_config.go
@@ -22,6 +22,7 @@ type Config struct {
 	MaxRequestRetry           int
 	DebugMode                 bool
 	HTTPSEnabled              bool
+	ResetDBFlag               bool
 	Clusters                  map[string]string
 }
 
@@ -45,6 +46,7 @@ func NewConfig() Config {
 	c.RedirectURL = "https://localhost:8443/"
 	c.IndexPath = "static/html/index.html"
 
+	c.ResetDBFlag = false
 	return c
 }
 
@@ -148,6 +150,11 @@ func (c *Config) GetDebugMode() bool {
 // GetHTTPSEnabled return hardcoded http-enabled from test configuration.
 func (c *Config) GetHTTPSEnabled() bool {
 	return c.HTTPSEnabled
+}
+
+// GetResetDBFlag return hardcode reset db flag from test configuration
+func (c *Config) GetResetDBFlag() bool {
+	return c.ResetDBFlag
 }
 
 func (c *Config) String() string {


### PR DESCRIPTION
This commit adds an environment variable `JC_RESET_DB_FLAG`. On this
environment variable being set, all relations would be dropped and
recreated, cleaning all the data.

Fixes #107 