### PR TITLE
Issue #299 Enable CORS properly

### DIFF
--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/api"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
@@ -263,10 +262,10 @@ func newAPIServer(api api.ProxyAPI) *http.Server {
 }
 
 func newJenkinsAPIServer(jenkinsAPI jenkinsapi.JenkinsAPI, config configuration.Configuration) *http.Server {
-	allowedMethods := strings.Split(config.GetAllowedOrigins(), ", ")
+	allowedOrigins := config.GetAllowedOrigins()
 	c := cors.New(cors.Options{
 		AllowCredentials: true,
-		AllowedOrigins:   allowedMethods,
+		AllowedOrigins:   allowedOrigins,
 		AllowedMethods:   []string{"POST"},
 	})
 	srv := &http.Server{

--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -255,19 +255,17 @@ func setupSignalChannel(cancel context.CancelFunc) {
 }
 
 func newAPIServer(api api.ProxyAPI) *http.Server {
-	c := cors.New(cors.Options{
-		AllowCredentials: true,
-	})
-	srv := &http.Server{
+	return &http.Server{
 		Addr:    apiRouterPort,
-		Handler: c.Handler(router.CreateAPIRouter(api)),
+		Handler: router.CreateAPIRouter(api),
 	}
-	return srv
 }
 
 func newJenkinsAPIServer(jenkinsAPI jenkinsapi.JenkinsAPI) *http.Server {
 	c := cors.New(cors.Options{
 		AllowCredentials: true,
+		AllowedOrigins:   []string{"https://openshift.io", "https://*.openshift.io"},
+		AllowedMethods:   []string{"POST"},
 	})
 	srv := &http.Server{
 		Addr:    jenkinsAPIRouterPort,

--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/api"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
@@ -174,7 +175,7 @@ func startWorkers(
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		srv := newJenkinsAPIServer(jenkinsAPI)
+		srv := newJenkinsAPIServer(jenkinsAPI, config)
 
 		go func() {
 			mainLogger.Infof("Starting Jenkins Status API router on port %s", jenkinsAPIRouterPort)
@@ -261,10 +262,11 @@ func newAPIServer(api api.ProxyAPI) *http.Server {
 	}
 }
 
-func newJenkinsAPIServer(jenkinsAPI jenkinsapi.JenkinsAPI) *http.Server {
+func newJenkinsAPIServer(jenkinsAPI jenkinsapi.JenkinsAPI, config configuration.Configuration) *http.Server {
+	allowedMethods := strings.Split(config.GetAllowedOrigins(), ", ")
 	c := cors.New(cors.Options{
 		AllowCredentials: true,
-		AllowedOrigins:   []string{"https://openshift.io", "https://*.openshift.io"},
+		AllowedOrigins:   allowedMethods,
 		AllowedMethods:   []string{"POST"},
 	})
 	srv := &http.Server{

--- a/cmd/fabric8-jenkins-proxy/main_cors_test.go
+++ b/cmd/fabric8-jenkins-proxy/main_cors_test.go
@@ -29,7 +29,7 @@ func TestAPIServerCORSHeaders(t *testing.T) {
 	config := mock.NewConfig()
 	apiServer := newJenkinsAPIServer(&MockJenkinsAPIImpl{}, &config)
 
-	reader, _ := http.NewRequest("POST", "/jenkins/start", nil)
+	reader, _ := http.NewRequest("POST", "/doesntmatter", nil)
 	// Check for origin "https://*.openshift.io"
 	randomOrigin := uuid.NewV4().String()
 	reader.Header.Set("Origin", "https://"+randomOrigin+".openshift.io")

--- a/cmd/fabric8-jenkins-proxy/main_cors_test.go
+++ b/cmd/fabric8-jenkins-proxy/main_cors_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
-	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy"
 	"github.com/julienschmidt/httprouter"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -39,17 +38,4 @@ func TestAPIServerCORSHeaders(t *testing.T) {
 	writer = httptest.NewRecorder()
 	apiServer.Handler.ServeHTTP(writer, reader)
 	assert.Equal(t, "https://.openshift.io", writer.Header().Get("access-control-allow-origin"))
-}
-
-func TestProxyCORSHeaders(t *testing.T) {
-	apiServer := newProxyServer(&proxy.Proxy{})
-	reader, _ := http.NewRequest("GET", "/", nil)
-	randomOrigin := uuid.NewV4().String()
-	reader.Header.Set("origin", randomOrigin) // allowing everything for now.
-
-	writer := httptest.NewRecorder()
-	apiServer.Handler.ServeHTTP(writer, reader)
-
-	assert.Equal(t, "", writer.Header().Get("access-control-allow-origin"))
-
 }

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -71,6 +71,9 @@ type Configuration interface {
 	// a response from the underlying jenkins server
 	GetGatewayTimeout() time.Duration
 
+	// GetAllowedOrigins returns string containing allowed origins separated with ", "
+	GetAllowedOrigins() string
+
 	// String returns a string representation of the configuration
 	String() string
 }

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -72,7 +72,7 @@ type Configuration interface {
 	GetGatewayTimeout() time.Duration
 
 	// GetAllowedOrigins returns string containing allowed origins separated with ", "
-	GetAllowedOrigins() string
+	GetAllowedOrigins() []string
 
 	// String returns a string representation of the configuration
 	String() string

--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -23,7 +23,7 @@ const (
 	defaultDebugMode                 = "false"
 	defaultHTTPSEnabled              = "false"
 	defaultGatewayTimeout            = "25s"
-	defaultAllowedOrigins            = "https://*openshift.io, https://localhost:*"
+	defaultAllowedOrigins            = "https://*openshift.io,https://localhost:*"
 )
 
 var (
@@ -271,11 +271,11 @@ func (c *EnvConfig) GetGatewayTimeout() time.Duration {
 }
 
 // GetAllowedOrigins returns string containing allowed origins separated with ", "
-func (c *EnvConfig) GetAllowedOrigins() string {
+func (c *EnvConfig) GetAllowedOrigins() []string {
 	callPtr, _, _, _ := runtime.Caller(0)
 	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
 
-	return value
+	return strings.Split(value, ",")
 }
 
 func (c *EnvConfig) String() string {

--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -23,6 +23,7 @@ const (
 	defaultDebugMode                 = "false"
 	defaultHTTPSEnabled              = "false"
 	defaultGatewayTimeout            = "25s"
+	defaultAllowedOrigins            = "https://*openshift.io, https://localhost:*"
 )
 
 var (
@@ -57,6 +58,7 @@ func init() {
 	settings["GetDebugMode"] = Setting{"JC_DEBUG_MODE", defaultDebugMode, []func(interface{}, string) error{util.IsBool}}
 	settings["GetHTTPSEnabled"] = Setting{"JC_ENABLE_HTTPS", defaultHTTPSEnabled, []func(interface{}, string) error{util.IsBool}}
 	settings["GetGatewayTimeout"] = Setting{"JC_GATEWAY_TIMEOUT", defaultGatewayTimeout, []func(interface{}, string) error{util.IsDuration}}
+	settings["GetAllowedOrigins"] = Setting{"JC_ALLOWED_ORIGINS", defaultAllowedOrigins, []func(interface{}, string) error{util.IsNotEmpty}}
 }
 
 // Setting is an element in the proxy configuration. It contains the environment
@@ -266,6 +268,14 @@ func (c *EnvConfig) GetGatewayTimeout() time.Duration {
 
 	d, _ := time.ParseDuration(value)
 	return d
+}
+
+// GetAllowedOrigins returns string containing allowed origins separated with ", "
+func (c *EnvConfig) GetAllowedOrigins() string {
+	callPtr, _, _, _ := runtime.Caller(0)
+	value := getConfigValueFromEnv(util.NameOfFunction(callPtr))
+
+	return value
 }
 
 func (c *EnvConfig) String() string {

--- a/internal/testutils/mock/mock_config.go
+++ b/internal/testutils/mock/mock_config.go
@@ -25,6 +25,7 @@ type Config struct {
 	DebugMode                 bool
 	HTTPSEnabled              bool
 	GatewayTimeout            time.Duration
+	AllowedOrigins            string
 	Clusters                  map[string]string
 }
 
@@ -48,6 +49,7 @@ func NewConfig() Config {
 	c.RedirectURL = "https://localhost:8443/"
 	c.IndexPath = "static/html/index.html"
 	c.GatewayTimeout = 25 * time.Second
+	c.AllowedOrigins = "https://*openshift.io, https://localhost:*"
 
 	return c
 }
@@ -157,6 +159,11 @@ func (c *Config) GetHTTPSEnabled() bool {
 // GetGatewayTimeout returns hardcoded gateway timeout from test configuration.
 func (c *Config) GetGatewayTimeout() time.Duration {
 	return c.GatewayTimeout
+}
+
+// GetAllowedOrigins returns hardcoded allowed origins
+func (c *Config) GetAllowedOrigins() string {
+	return c.AllowedOrigins
 }
 
 func (c *Config) String() string {

--- a/internal/testutils/mock/mock_config.go
+++ b/internal/testutils/mock/mock_config.go
@@ -25,7 +25,7 @@ type Config struct {
 	DebugMode                 bool
 	HTTPSEnabled              bool
 	GatewayTimeout            time.Duration
-	AllowedOrigins            string
+	AllowedOrigins            []string
 	Clusters                  map[string]string
 }
 
@@ -49,7 +49,7 @@ func NewConfig() Config {
 	c.RedirectURL = "https://localhost:8443/"
 	c.IndexPath = "static/html/index.html"
 	c.GatewayTimeout = 25 * time.Second
-	c.AllowedOrigins = "https://*openshift.io, https://localhost:*"
+	c.AllowedOrigins = []string{"https://*openshift.io", "https://localhost:*"}
 
 	return c
 }
@@ -162,7 +162,7 @@ func (c *Config) GetGatewayTimeout() time.Duration {
 }
 
 // GetAllowedOrigins returns hardcoded allowed origins
-func (c *Config) GetAllowedOrigins() string {
+func (c *Config) GetAllowedOrigins() []string {
 	return c.AllowedOrigins
 }
 


### PR DESCRIPTION
Set AllowOrigins and AllowMethods
Removed unnecessary CORS support for unexposed API and removed
their tests
Added tests for CORS support of exposed Jenkins API
Fixes #299 