### PR TITLE
Issue #299 Enable CORS properly

### DIFF
--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -262,11 +262,11 @@ func newAPIServer(api api.ProxyAPI) *http.Server {
 }
 
 func newJenkinsAPIServer(jenkinsAPI jenkinsapi.JenkinsAPI, config configuration.Configuration) *http.Server {
-	allowedOrigins := config.GetAllowedOrigins()
 	c := cors.New(cors.Options{
-		AllowCredentials: true,
-		AllowedOrigins:   allowedOrigins,
-		AllowedMethods:   []string{"POST"},
+		AllowedOrigins: config.GetAllowedOrigins(),
+		AllowedMethods: []string{"HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"},
+		AllowedHeaders: []string{"*"},
+		Debug:          config.GetDebugMode(),
 	})
 	srv := &http.Server{
 		Addr:    jenkinsAPIRouterPort,


### PR DESCRIPTION
Previous attempt do enable CORS didn't have AllowHeaders = "*" set
so passing in 'Authorization' header which was required for `start`
api resulted in the following error:

```
Response to preflight request doesn't pass access control check:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
Origin 'https://prod-preview.openshift.io' is therefore not allowed access.
```

This has been fixed by adding `AllowedHeaders: []string{"*"},`

Additionally, the patch also allows all standard CRUD methods and
enables Debug logs for `cors` if `config.GetDebugMode()` is set