### PR TITLE
Issue #299 Enable CORS properly

### DIFF
--- a/cmd/fabric8-jenkins-proxy/main_cors_test.go
+++ b/cmd/fabric8-jenkins-proxy/main_cors_test.go
@@ -30,6 +30,7 @@ func TestAPIServerCORSHeaders(t *testing.T) {
 	apiServer := newJenkinsAPIServer(&MockJenkinsAPIImpl{}, &config)
 
 	reader, _ := http.NewRequest("POST", "/doesntmatter", nil)
+
 	// Check for origin "https://*.openshift.io"
 	randomOrigin := uuid.NewV4().String()
 	reader.Header.Set("Origin", "https://"+randomOrigin+".openshift.io")
@@ -42,6 +43,20 @@ func TestAPIServerCORSHeaders(t *testing.T) {
 	writer = httptest.NewRecorder()
 	apiServer.Handler.ServeHTTP(writer, reader)
 	assert.Equal(t, "https://openshift.io", writer.Header().Get("access-control-allow-origin"))
+
+	// Check for origin "https://localhost:*"
+	randomOrigin = uuid.NewV4().String()
+	reader.Header.Set("Origin", "https://localhost:"+randomOrigin)
+	writer = httptest.NewRecorder()
+	apiServer.Handler.ServeHTTP(writer, reader)
+	assert.Equal(t, "https://localhost:"+randomOrigin, writer.Header().Get("access-control-allow-origin"))
+
+	// Check for origin "http://localhost:*"
+	randomOrigin = uuid.NewV4().String()
+	reader.Header.Set("Origin", "http://localhost:"+randomOrigin)
+	writer = httptest.NewRecorder()
+	apiServer.Handler.ServeHTTP(writer, reader)
+	assert.Equal(t, "http://localhost:"+randomOrigin, writer.Header().Get("access-control-allow-origin"))
 
 	// Check that we dont allow a random origin
 	randomOrigin = uuid.NewV4().String()

--- a/internal/configuration/env_config.go
+++ b/internal/configuration/env_config.go
@@ -23,7 +23,7 @@ const (
 	defaultDebugMode                 = "false"
 	defaultHTTPSEnabled              = "false"
 	defaultGatewayTimeout            = "25s"
-	defaultAllowedOrigins            = "https://*openshift.io,https://localhost:*"
+	defaultAllowedOrigins            = "https://*openshift.io,https://localhost:*,http://localhost:*"
 )
 
 var (

--- a/internal/testutils/mock/mock_config.go
+++ b/internal/testutils/mock/mock_config.go
@@ -49,7 +49,7 @@ func NewConfig() Config {
 	c.RedirectURL = "https://localhost:8443/"
 	c.IndexPath = "static/html/index.html"
 	c.GatewayTimeout = 25 * time.Second
-	c.AllowedOrigins = []string{"https://*openshift.io", "https://localhost:*"}
+	c.AllowedOrigins = []string{"https://*openshift.io", "https://localhost:*", "http://localhost:*"}
 
 	return c
 }


### PR DESCRIPTION
Added `http://localhost:*`
Added tests to check that `https://localhost:*` and
`http://localhost:*` are among allowed origin which can pass access
control check
#299