### PR TITLE
Issue #303 Provide an api to get the status of jenkins pods (#303)

### DIFF
--- a/cmd/fabric8-jenkins-proxy/main_cors_test.go
+++ b/cmd/fabric8-jenkins-proxy/main_cors_test.go
@@ -21,6 +21,11 @@ func (api *MockJenkinsAPIImpl) Start(w http.ResponseWriter, r *http.Request, _ h
 	json.NewEncoder(w).Encode(resp)
 }
 
+func (api *MockJenkinsAPIImpl) Status(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	resp := clients.StatusResponse{}
+	json.NewEncoder(w).Encode(resp)
+}
+
 func TestAPIServerCORSHeaders(t *testing.T) {
 	config := mock.NewConfig()
 	apiServer := newJenkinsAPIServer(&MockJenkinsAPIImpl{}, &config)

--- a/internal/jenkinsapi/jenkinsapi_test.go
+++ b/internal/jenkinsapi/jenkinsapi_test.go
@@ -15,21 +15,56 @@ import (
 
 func Test_Start(t *testing.T) {
 	tenant, idler := setupDependencyServices()
-	jenkinsAPI := jenkinsapi.NewJenkinsAPI(tenant, idler)
+	jenkinsapi := jenkinsapi.NewJenkinsAPI(tenant, idler)
 
 	r := httptest.NewRequest("GET", "/doesntmatter", nil)
 	r.Header.Set("Authorization", "Bearer InvalidToken")
 	w := httptest.NewRecorder()
-	jenkinsAPI.Start(w, r, nil)
+	jenkinsapi.Start(w, r, nil)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
 	r = httptest.NewRequest("GET", "/doesntmatter", nil)
 	r.Header.Set("Authorization", "Bearer ValidToken")
 	w = httptest.NewRecorder()
-	jenkinsAPI.Start(w, r, nil)
+	jenkinsapi.Start(w, r, nil)
 	assert.Equal(t, http.StatusOK, w.Code)
 	fmt.Printf(w.Body.String())
 	assert.Equal(t, "{\"data\":{\"state\":\""+string(idler.IdlerState)+"\"}}\n", w.Body.String())
+}
+
+func Test_Status(t *testing.T) {
+	tenant, idler := setupDependencyServices()
+	jenkinsapi := jenkinsapi.NewJenkinsAPI(tenant, idler)
+
+	r := httptest.NewRequest("GET", "/someendpoint", nil)
+	r.Header.Set("Authorization", "Bearer InvalidToken")
+	w := httptest.NewRecorder()
+	jenkinsapi.Status(w, r, nil)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func Test_Status_unauthorized(t *testing.T) {
+	tenant, idler := setupDependencyServices()
+	jenkinsapi := jenkinsapi.NewJenkinsAPI(tenant, idler)
+
+	r := httptest.NewRequest("GET", "/someendpoint", nil)
+	r.Header.Set("Authorization", "Bearer ValidToken")
+	w := httptest.NewRecorder()
+	jenkinsapi.Status(w, r, nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+	fmt.Printf(w.Body.String())
+	assert.Equal(t, "{\"data\":{\"state\":\""+string(idler.IdlerState)+"\"}}\n", w.Body.String())
+}
+
+func Test_Status_bad_idler(t *testing.T) {
+	failedTenant, failedIdler := setupBadDependencyServices()
+	failedJenkinsAPI := jenkinsapi.NewJenkinsAPI(failedTenant, failedIdler)
+
+	r := httptest.NewRequest("GET", "/someendpoint", nil)
+	r.Header.Set("Authorization", "Bearer ValidToken")
+	w := httptest.NewRecorder()
+	failedJenkinsAPI.Status(w, r, nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func setupDependencyServices() (clients.TenantService, *mock.Idler) {
@@ -41,7 +76,21 @@ func setupDependencyServices() (clients.TenantService, *mock.Idler) {
 	tenant := mock.Tenant{}
 
 	// Create Idler client
-	idler := mock.NewMockIdler(configuration.IdlerURL, clients.PodState("idled"))
+	idler := mock.NewMockIdler(configuration.IdlerURL, clients.PodState("idled"), false)
+
+	return &tenant, idler
+}
+
+func setupBadDependencyServices() (clients.TenantService, *mock.Idler) {
+	configuration := mock.NewConfig()
+
+	configuration.IdlerURL = "doesnt_matter"
+
+	// Create tenant client
+	tenant := mock.Tenant{}
+
+	// Create Idler client
+	idler := mock.NewMockIdler(configuration.IdlerURL, clients.PodState("idled"), true)
 
 	return &tenant, idler
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -24,6 +24,7 @@ func CreateJenkinsAPIRouter(jenkinsAPI jenkinsapi.JenkinsAPI) *httprouter.Router
 	// Create router for API
 	jenkinsAPIRouter := httprouter.New()
 	jenkinsAPIRouter.POST("/api/jenkins/start", jenkinsAPI.Start)
+	jenkinsAPIRouter.GET("/api/jenkins/status", jenkinsAPI.Status)
 	return jenkinsAPIRouter
 }
 

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -67,6 +67,23 @@ func (api *mockJenkinsAPI) Start(w http.ResponseWriter, r *http.Request, _ httpr
 	json.NewEncoder(w).Encode(resp)
 }
 
+// Status mock returns the Jenkins status for current user
+func (api *mockJenkinsAPI) Status(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	resp := clients.StatusResponse{}
+
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		jenkinsapi.HandleError(w, resp, errors.New("Could not find Bearer Token in Authorization Header"), http.StatusUnauthorized)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	resp.Data = &clients.JenkinsInfo{
+		State: clients.UnknownState,
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
 func Test_API_routes_are_setup(t *testing.T) {
 	mockedProxyAPI := &mockProxyAPI{}
 	mockedRouter := CreateAPIRouter(mockedProxyAPI)

--- a/internal/testutils/mock/mock_idler.go
+++ b/internal/testutils/mock/mock_idler.go
@@ -10,18 +10,23 @@ import (
 type Idler struct {
 	idlerAPI   string
 	IdlerState clients.PodState
+	throwError bool // Used to test error scenarios
 }
 
 // NewMockIdler is a constructor for mock.Idler
-func NewMockIdler(idlerAPI string, state clients.PodState) (idler *Idler) {
+func NewMockIdler(idlerAPI string, state clients.PodState, throwError bool) (idler *Idler) {
 	return &Idler{
 		idlerAPI:   idlerAPI,
 		IdlerState: state,
+		throwError: throwError,
 	}
 }
 
 // State just returns the value set in Idler.state
 func (i *Idler) State(tenant string, openShiftAPIURL string) (clients.PodState, error) {
+	if i.throwError == true {
+		return clients.UnknownState, errors.New("This error is invoked for mocking error scenarios")
+	}
 	if openShiftAPIURL == "Valid_OpenShift_API_URL" {
 		return i.IdlerState, nil
 	}


### PR DESCRIPTION
There are lots of use cases where UI only wants to know the state of pod
before calling the api. So lets provide an api to get the status of jenkins
pods GET /api/jenkins/status that returns status like start api.

#303