### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 ENV LANG=en_US.utf8

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-REGISTRY_URI = "push.registry.devshift.net"
+REGISTRY_URI = "quay.io"
 REGISTRY_NS = "fabric8-services"
 REGISTRY_IMAGE = "fabric8-jenkins-proxy"
 
 ifeq ($(TARGET),rhel)
 	DOCKERFILE_DEPLOY := Dockerfile.deploy.rhel
-	REGISTRY_URL = ${REGISTRY_URI}/osio-prod/${REGISTRY_NS}/${REGISTRY_IMAGE}
+	REGISTRY_URL = ${REGISTRY_URI}/openshiftio/rhel-${REGISTRY_NS}-${REGISTRY_IMAGE}
 else
 	DOCKERFILE_DEPLOY := Dockerfile.deploy
-	REGISTRY_URL = ${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+	REGISTRY_URL = ${REGISTRY_URI}/openshiftio/${REGISTRY_NS}-${REGISTRY_IMAGE}
 endif
 
 IMAGE_TAG ?= $(shell git rev-parse --short HEAD)

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -12,8 +12,9 @@ set -e
 #   None
 ###################################################################################
 function setup_build_environment() {
-    [ -f jenkins-env ] && cat jenkins-env | grep -e GIT -e DEVSHIFT -e JOB_NAME > inherit-env
-    [ -f inherit-env ] && . inherit-env
+    if [ -f jenkins-env.json ]; then
+      eval "$(./env-toolkit load -f jenkins-env.json -r ^GIT ^DEVSHIFT ^QUAY ^JOB_NAME$)"
+    fi
 
     # We need to disable selinux for now, XXX
     /usr/sbin/setenforce 0 || :
@@ -59,7 +60,7 @@ setup_workspace
 
 cd $GOPATH/src/github.com/fabric8-services/fabric8-jenkins-proxy
 echo "HEAD of repository `git rev-parse --short HEAD`"
-make login REGISTRY_USER=${DEVSHIFT_USERNAME} REGISTRY_PASSWORD=${DEVSHIFT_PASSWORD}
+make login REGISTRY_USER=${QUAY_USERNAME} REGISTRY_PASSWORD=${QUAY_PASSWORD}
 make all
 
 if [[ "$JOB_NAME" = "devtools-fabric8-jenkins-proxy-build-master" ]]; then

--- a/openshift/jenkins-proxy.app.yaml
+++ b/openshift/jenkins-proxy.app.yaml
@@ -156,7 +156,7 @@ objects:
     type: ClusterIP
 parameters:
 - name: IMAGE
-  value: registry.devshift.net/fabric8-services/fabric8-jenkins-proxy
+  value: quay.io/openshiftio/rhel-fabric8-services-fabric8-jenkins-proxy
   required: true
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-openshiftio/pull/954