### PR TITLE
Fix #315 Remove more references to KeyCloak

### DIFF
--- a/internal/configuration/env_config_test.go
+++ b/internal/configuration/env_config_test.go
@@ -35,7 +35,6 @@ func Test_setting_required_parameters_lets_you_create_configuration(t *testing.T
 	os.Setenv("JC_F8TENANT_API_URL", "http://localhost:1234")
 	os.Setenv("JC_AUTH_URL", "http://localhost:1235")
 	os.Setenv("JC_WIT_API_URL", "http://localhost:1236")
-	os.Setenv("JC_KEYCLOAK_URL", "http://localhost:1237")
 	os.Setenv("JC_IDLER_API_URL", "http://localhost:1238")
 
 	os.Setenv("JC_AUTH_TOKEN", "snafu")

--- a/openshift/jenkins-proxy.app.yaml
+++ b/openshift/jenkins-proxy.app.yaml
@@ -48,11 +48,6 @@ objects:
               configMapKeyRef:
                 name: jenkins-proxy
                 key: redirect.url
-          - name: JC_KEYCLOAK_URL
-            valueFrom:
-              configMapKeyRef:
-                name: auth
-                key: keycloak.url
           - name: JC_AUTH_URL
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
Previous commits did not completely remove all references to keycloak.
This patch fixes it.