### PR TITLE
Fix #4083 Lower initial wait for Jenkins to start

### DIFF
--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -57,7 +57,7 @@ func (p *Proxy) processTemplate(w http.ResponseWriter, ns string, requestLogEntr
 	data := struct {
 		RetryMaxInterval int
 		RetryMinInterval int
-	}{2 * 60, 15}
+	}{45, 15}
 
 	requestLogEntry.WithField("ns", ns).Debug("Templating index.html")
 	err = tmplt.Execute(w, data)


### PR DESCRIPTION
With more resources allocated to Jenkins, it usually start under
30 seconds, so this patch reduces the initial waiting time to 45 seconds