### PR TITLE
Issue #321 Check if Session cookie is Valid

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/Azure/go-ansiterm"
-  packages = [".","winterm"]
+  packages = [
+    ".",
+    "winterm"
+  ]
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
@@ -51,7 +54,33 @@
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/filters","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/swarm/runtime","api/types/versions","opts","pkg/archive","pkg/fileutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/jsonmessage","pkg/longpath","pkg/mount","pkg/pools","pkg/stdcopy","pkg/system","pkg/term","pkg/term/windows"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/swarm/runtime",
+    "api/types/versions",
+    "opts",
+    "pkg/archive",
+    "pkg/fileutils",
+    "pkg/homedir",
+    "pkg/idtools",
+    "pkg/ioutils",
+    "pkg/jsonmessage",
+    "pkg/longpath",
+    "pkg/mount",
+    "pkg/pools",
+    "pkg/stdcopy",
+    "pkg/system",
+    "pkg/term",
+    "pkg/term/windows"
+  ]
   revision = "fe8aac6f5ae413a967adb0adad0b54abdfb825c4"
 
 [[projects]]
@@ -93,7 +122,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
@@ -122,7 +161,10 @@
 
 [[projects]]
   name = "github.com/lib/pq"
-  packages = [".","oid"]
+  packages = [
+    ".",
+    "oid"
+  ]
   revision = "83612a56d3dd153a94a629cd64925371c9adad78"
 
 [[projects]]
@@ -157,13 +199,19 @@
 
 [[projects]]
   name = "github.com/opencontainers/image-spec"
-  packages = ["specs-go","specs-go/v1"]
+  packages = [
+    "specs-go",
+    "specs-go/v1"
+  ]
   revision = "d60099175f88c47cd379c4738d158884749ed235"
   version = "v1.0.1"
 
 [[projects]]
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer/system","libcontainer/user"]
+  packages = [
+    "libcontainer/system",
+    "libcontainer/user"
+  ]
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
@@ -193,7 +241,10 @@
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
@@ -206,13 +257,22 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [".","internal/util","nfs","xfs"]
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
   revision = "780932d4fbbe0e69b84c34c20f5c8d0981e109ea"
 
 [[projects]]
@@ -229,13 +289,19 @@
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
-  packages = [".","hooks/test"]
+  packages = [
+    ".",
+    "hooks/test"
+  ]
   revision = "202f25545ea4cf9b191ff7f846df5d87c9382c2b"
   version = "v1.0.0"
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
   version = "v1.0.2"
 
@@ -271,27 +337,51 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","html","html/atom"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "html",
+    "html/atom"
+  ]
   revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "af50095a40f9041b3b38960738837185c26e9419"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+
+[[projects]]
+  name = "gopkg.in/h2non/gock.v1"
+  packages = ["."]
+  revision = "a6029d17e101ac1594adafea9e63fd8c988a8701"
+  version = "v1.0.12"
 
 [[projects]]
   name = "gopkg.in/ory-am/dockertest.v3"
@@ -308,6 +398,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1fdccbea14f287a8a6e97e381ad11328ba335d53b7e25bc3f0ca924f1e452757"
+  inputs-digest = "684701caf33d2760acfbfa894b2a50536dfcecd34817702a27407fd29ebc3700"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,3 +48,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/matryer/resync"
+
+[[constraint]]
+  name = "gopkg.in/h2non/gock.v1"
+  version = "=v1.0.12"

--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -99,14 +99,11 @@ func main() {
 	}
 	mainLogger.WithField("clusters", clusters).Info("Retrieved cluster view")
 
-	codebase := proxy.NewCodebase(wit, &tenant, log.WithFields(log.Fields{"component": "proxy"}))
-	jenkins := proxy.NewJenkins(clusters, idler, tenant, log.WithFields(log.Fields{"component": "proxy"}))
-
-	start(config, codebase, jenkins, store, clusters)
+	start(config, idler, &tenant, wit, store, clusters)
 }
 
-func start(config configuration.Configuration, codebase proxy.CodebaseService, jenkins proxy.JenkinsService, store storage.Store, clusters map[string]string) {
-	proxy, err := proxy.NewProxy(codebase, jenkins, store, config, clusters)
+func start(config configuration.Configuration, idler clients.IdlerService, tenant *clients.Tenant, wit clients.WIT, store storage.Store, clusters map[string]string) {
+	proxy, err := proxy.NewProxy(idler, tenant, wit, store, config, clusters)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -102,7 +102,7 @@ func main() {
 	start(config, idler, &tenant, wit, store, clusters)
 }
 
-func start(config configuration.Configuration, idler clients.IdlerService, tenant clients.TenantService, wit clients.WIT, store storage.Store, clusters map[string]string) {
+func start(config configuration.Configuration, idler clients.IdlerService, tenant clients.TenantService, wit clients.WITService, store storage.Store, clusters map[string]string) {
 	proxy, err := proxy.NewProxy(idler, tenant, wit, store, config, clusters)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -99,11 +99,14 @@ func main() {
 	}
 	mainLogger.WithField("clusters", clusters).Info("Retrieved cluster view")
 
-	start(config, &tenant, wit, idler, store, clusters)
+	codebase := proxy.NewCodebase(wit, &tenant, log.WithFields(log.Fields{"component": "proxy"}))
+	jenkins := proxy.NewJenkins(clusters, idler, tenant, log.WithFields(log.Fields{"component": "proxy"}))
+
+	start(config, codebase, jenkins, store, clusters)
 }
 
-func start(config configuration.Configuration, tenant *clients.Tenant, wit clients.WIT, idler clients.IdlerService, store storage.Store, clusters map[string]string) {
-	proxy, err := proxy.NewProxy(tenant, wit, idler, store, config, clusters)
+func start(config configuration.Configuration, codebase proxy.CodebaseService, jenkins proxy.JenkinsService, store storage.Store, clusters map[string]string) {
+	proxy, err := proxy.NewProxy(codebase, jenkins, store, config, clusters)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -102,7 +102,7 @@ func main() {
 	start(config, idler, &tenant, wit, store, clusters)
 }
 
-func start(config configuration.Configuration, idler clients.IdlerService, tenant *clients.Tenant, wit clients.WIT, store storage.Store, clusters map[string]string) {
+func start(config configuration.Configuration, idler clients.IdlerService, tenant clients.TenantService, wit clients.WIT, store storage.Store, clusters map[string]string) {
 	proxy, err := proxy.NewProxy(idler, tenant, wit, store, config, clusters)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/fabric8-jenkins-proxy/main_test.go
+++ b/cmd/fabric8-jenkins-proxy/main_test.go
@@ -111,7 +111,7 @@ func TestProxy(t *testing.T) {
 
 	clusters := make(map[string]string)
 	clusters["https://api.free-stg.openshift.com/"] = "1b7d.free-stg.openshiftapps.com"
-	start(&mockConfig, &tenant, wit, idler, store, clusters)
+	start(&mockConfig, idler, &tenant, wit, store, clusters)
 
 	// TODO - Test an actual workflow by triggering some of the MockURLs
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,8 +17,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// AuthService talks to fabric8-auth for authentication and authorication
-type AuthService interface {
+// Service talks to fabric8-auth for authentication and authorication
+type Service interface {
 	UIDFromToken(accessToken string) (sub string, err error)
 	OSOTokenForCluster(clusterURL, accessToken string) (osoToken string, err error)
 	CreateRedirectURL(to string) string
@@ -43,24 +43,26 @@ type TokenJSON struct {
 	Errors           []util.ErrorInfo
 }
 
+// Key is a cryptographic key used for authentication and authorization
 type Key struct {
 	KID string `json:"kid"`
 	Key string `json:"key"`
 }
 
+// KeyList is a list of cryptographics keys used for authentication and authorization
 type KeyList struct {
 	Keys []Key `json:"keys"`
 }
 
-var defaultClient AuthService
+var defaultClient Service
 
 // SetDefaultClient set auth client that will be returned by auth.DefaultClient
-func SetDefaultClient(c AuthService) {
+func SetDefaultClient(c Service) {
 	defaultClient = c
 }
 
 // DefaultClient returns default auth client
-func DefaultClient() (AuthService, error) {
+func DefaultClient() (Service, error) {
 	if defaultClient != nil {
 		return defaultClient, nil
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Service talks to fabric8-auth for authentication and authorication
+// Service talks to fabric8-auth for authentication and authorization
 type Service interface {
 	UIDFromToken(accessToken string) (sub string, err error)
 	OSOTokenForCluster(clusterURL, accessToken string) (osoToken string, err error)
@@ -41,17 +41,6 @@ type TokenJSON struct {
 	ExpiresIn        int    `json:"expires_in"`
 	RefreshExpiresIn int    `json:"refresh_expires_in"`
 	Errors           []util.ErrorInfo
-}
-
-// Key is a cryptographic key used for authentication and authorization
-type Key struct {
-	KID string `json:"kid"`
-	Key string `json:"key"`
-}
-
-// KeyList is a list of cryptographics keys used for authentication and authorization
-type KeyList struct {
-	Keys []Key `json:"keys"`
 }
 
 var defaultClient Service
@@ -225,7 +214,16 @@ func (c *Client) updatePublicKeys() error {
 		return err
 	}
 
-	keys := &KeyList{}
+	// key is a cryptographic key used for authentication and authorization
+	type key struct {
+		KID string `json:"kid"`
+		Key string `json:"key"`
+	}
+	// keyList is a list of cryptographics keys used for authentication and authorization
+	type keyList struct {
+		Keys []key `json:"keys"`
+	}
+	keys := &keyList{}
 
 	if err = json.Unmarshal(body, keys); err != nil {
 		return err

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -90,7 +90,9 @@ func newMockAuthService(responses []string) *mockAuthService {
 }
 
 func TestClient_default_is_nil(t *testing.T) {
-	assert.Nil(t, DefaultClient(), "auth default client is nil")
+	authClient, err := DefaultClient()
+	assert.NotNil(t, err, "auth default client is nil")
+	assert.Nil(t, authClient, "auth default client is nil")
 }
 
 func TestClient_no_update_if_success(t *testing.T) {

--- a/internal/auth/mock_auth.go
+++ b/internal/auth/mock_auth.go
@@ -6,10 +6,12 @@ import (
 	"strings"
 )
 
+// MockAuth is a mock implementation of auth service
 type MockAuth struct {
 	URL string
 }
 
+// NewMockAuth creates a mock auth client
 func NewMockAuth(authURL string) *MockAuth {
 	return &MockAuth{
 		URL: authURL,

--- a/internal/auth/mock_auth.go
+++ b/internal/auth/mock_auth.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type MockAuth struct {
+	URL string
+}
+
+func NewMockAuth(authURL string) *MockAuth {
+	return &MockAuth{
+		URL: authURL,
+	}
+}
+
+// UIDFromToken returns user identity given a raw jwt token
+func (c *MockAuth) UIDFromToken(accessToken string) (sub string, err error) {
+	return "test_subject", nil
+}
+
+// OSOTokenForCluster returns Openshift online token given the clusterURL and raw JWT token
+func (c *MockAuth) OSOTokenForCluster(clusterURL, accessToken string) (osoToken string, err error) {
+	return "test_oso_token", nil
+}
+
+// CreateRedirectURL gets us the URI which we are supposed to use to logging in
+// with fabric8-auth Client on giving auth Client URL and redirectURL as input.
+func (c *MockAuth) CreateRedirectURL(to string) string {
+	return fmt.Sprintf(
+		"%s/api/login?redirect=%s",
+		strings.TrimRight(c.URL, "/"), url.PathEscape(to))
+}

--- a/internal/clients/tenant.go
+++ b/internal/clients/tenant.go
@@ -156,7 +156,7 @@ func (t Tenant) GetNamespace(accessToken string) (namespace Namespace, err error
 
 	namespace, err = GetNamespaceByType(ti, "jenkins")
 	if err != nil {
-		return Namespace{}, err
+		return namespace, err
 	}
 
 	return namespace, nil

--- a/internal/clients/tenant.go
+++ b/internal/clients/tenant.go
@@ -142,16 +142,16 @@ func GetNamespaceByType(ti TenantInfo, typ string) (r Namespace, err error) {
 func (t Tenant) GetNamespace(accessToken string) (namespace Namespace, err error) {
 	authClient, err := auth.DefaultClient()
 	if err != nil {
-		return Namespace{}, err
+		return namespace, err
 	}
 	uid, err := authClient.UIDFromToken(accessToken)
 	if err != nil {
-		return Namespace{}, err
+		return namespace, err
 	}
 
 	ti, err := t.GetTenantInfo(uid)
 	if err != nil {
-		return Namespace{}, err
+		return namespace, err
 	}
 
 	namespace, err = GetNamespaceByType(ti, "jenkins")

--- a/internal/clients/tenant.go
+++ b/internal/clients/tenant.go
@@ -140,19 +140,23 @@ func GetNamespaceByType(ti TenantInfo, typ string) (r Namespace, err error) {
 
 // GetNamespace gets namespace given appropriate accessToken
 func (t Tenant) GetNamespace(accessToken string) (namespace Namespace, err error) {
-	uid, err := auth.DefaultClient().UIDFromToken(accessToken)
+	authClient, err := auth.DefaultClient()
 	if err != nil {
-		return
+		return Namespace{}, err
+	}
+	uid, err := authClient.UIDFromToken(accessToken)
+	if err != nil {
+		return Namespace{}, err
 	}
 
 	ti, err := t.GetTenantInfo(uid)
 	if err != nil {
-		return
+		return Namespace{}, err
 	}
 
 	namespace, err = GetNamespaceByType(ti, "jenkins")
 	if err != nil {
-		return
+		return Namespace{}, err
 	}
 
 	return namespace, nil

--- a/internal/clients/wit.go
+++ b/internal/clients/wit.go
@@ -9,8 +9,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// WIT describes work item tracker service of OSIO.
-type WIT interface {
+// WITService describes work item tracker service of OSIO.
+type WITService interface {
 	SearchCodebase(repo string) (*WITInfo, error)
 }
 
@@ -21,7 +21,7 @@ type wit struct {
 }
 
 // NewWIT creates an instance of WIT client.
-func NewWIT(url string, token string) WIT {
+func NewWIT(url string, token string) WITService {
 	return &wit{
 		witURL:    url,
 		authToken: token,

--- a/internal/proxy/codebase.go
+++ b/internal/proxy/codebase.go
@@ -28,7 +28,7 @@ func NewCodebase(wit clients.WITService, tenant clients.TenantService, repositor
 		wit:                wit,
 		tenant:             tenant,
 		repositoryCloneURL: repositoryCloneURL,
-		logger:             logger,
+		logger:             logger.WithFields(log.Fields{"repository": repositoryCloneURL}),
 	}
 }
 

--- a/internal/proxy/codebase.go
+++ b/internal/proxy/codebase.go
@@ -16,14 +16,14 @@ type CodebaseService interface {
 
 // Codebase is an implementation of the codebase interface
 type Codebase struct {
-	wit                clients.WIT
+	wit                clients.WITService
 	tenant             clients.TenantService
 	repositoryCloneURL string
 	logger             *log.Entry
 }
 
 // NewCodebase gets an instance of
-func NewCodebase(wit clients.WIT, tenant clients.TenantService, repositoryCloneURL string, logger *log.Entry) *Codebase {
+func NewCodebase(wit clients.WITService, tenant clients.TenantService, repositoryCloneURL string, logger *log.Entry) *Codebase {
 	return &Codebase{
 		wit:                wit,
 		tenant:             tenant,

--- a/internal/proxy/codebase.go
+++ b/internal/proxy/codebase.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+	log "github.com/sirupsen/logrus"
+)
+
+// CodebaseService contains methods that deals with code repository and
+// code hosting services
+type CodebaseService interface {
+	Namespace(repositoryCloneURL string) (clients.Namespace, error)
+}
+
+// Codebase is an implementation of the codebase interface
+type Codebase struct {
+	wit    clients.WIT
+	tenant clients.TenantService
+
+	logger *log.Entry
+}
+
+// NewCodebase gets an instance of
+func NewCodebase(wit clients.WIT, tenant clients.TenantService, logger *log.Entry) *Codebase {
+	return &Codebase{
+		wit:    wit,
+		tenant: tenant,
+		logger: logger,
+	}
+}
+
+// Namespace gives us details of user who owns given repository
+func (codebase *Codebase) Namespace(repositoryCloneURL string) (clients.Namespace, error) {
+	wi, err := codebase.wit.SearchCodebase(repositoryCloneURL)
+	if err != nil {
+		return clients.Namespace{}, err
+	}
+
+	if len(strings.TrimSpace(wi.OwnedBy)) == 0 {
+		return clients.Namespace{}, fmt.Errorf("unable to determine tenant id for repository %s", repositoryCloneURL)
+	}
+
+	codebase.logger.Infof("Found id %s for repo %s", wi.OwnedBy, repositoryCloneURL)
+	ti, err := codebase.tenant.GetTenantInfo(wi.OwnedBy)
+	if err != nil {
+		return clients.Namespace{}, err
+	}
+
+	n, err := clients.GetNamespaceByType(ti, ServiceName)
+	if err != nil {
+		return clients.Namespace{}, err
+	}
+
+	return n, nil
+}

--- a/internal/proxy/codebase.go
+++ b/internal/proxy/codebase.go
@@ -16,34 +16,35 @@ type CodebaseService interface {
 
 // Codebase is an implementation of the codebase interface
 type Codebase struct {
-	wit    clients.WIT
-	tenant clients.TenantService
-
-	logger *log.Entry
+	wit                clients.WIT
+	tenant             clients.TenantService
+	repositoryCloneURL string
+	logger             *log.Entry
 }
 
 // NewCodebase gets an instance of
-func NewCodebase(wit clients.WIT, tenant clients.TenantService, logger *log.Entry) *Codebase {
+func NewCodebase(wit clients.WIT, tenant clients.TenantService, repositoryCloneURL string, logger *log.Entry) *Codebase {
 	return &Codebase{
-		wit:    wit,
-		tenant: tenant,
-		logger: logger,
+		wit:                wit,
+		tenant:             tenant,
+		repositoryCloneURL: repositoryCloneURL,
+		logger:             logger,
 	}
 }
 
 // Namespace gives us details of user who owns given repository
-func (codebase *Codebase) Namespace(repositoryCloneURL string) (clients.Namespace, error) {
-	wi, err := codebase.wit.SearchCodebase(repositoryCloneURL)
+func (c *Codebase) Namespace() (clients.Namespace, error) {
+	wi, err := c.wit.SearchCodebase(c.repositoryCloneURL)
 	if err != nil {
 		return clients.Namespace{}, err
 	}
 
 	if len(strings.TrimSpace(wi.OwnedBy)) == 0 {
-		return clients.Namespace{}, fmt.Errorf("unable to determine tenant id for repository %s", repositoryCloneURL)
+		return clients.Namespace{}, fmt.Errorf("unable to determine tenant id for repository %s", c.repositoryCloneURL)
 	}
 
-	codebase.logger.Infof("Found id %s for repo %s", wi.OwnedBy, repositoryCloneURL)
-	ti, err := codebase.tenant.GetTenantInfo(wi.OwnedBy)
+	c.logger.Infof("Found id %s for repo %s", wi.OwnedBy, c.repositoryCloneURL)
+	ti, err := c.tenant.GetTenantInfo(wi.OwnedBy)
 	if err != nil {
 		return clients.Namespace{}, err
 	}

--- a/internal/proxy/cookies/cookies.go
+++ b/internal/proxy/cookies/cookies.go
@@ -59,10 +59,6 @@ func IsSessionOrIdledCookie(c *http.Cookie) bool {
 	return IsSessionCookie(c) || IsIdledCookie(c)
 }
 
-func anyCookie(_ *http.Cookie) bool {
-	return true
-}
-
 // SetIdledCookie set a cookie to indicate that jenkins is idled for namespace stored
 // in cache with cookie value as cache key
 func SetIdledCookie(w http.ResponseWriter) string {

--- a/internal/proxy/cookies/cookies.go
+++ b/internal/proxy/cookies/cookies.go
@@ -18,6 +18,7 @@ const (
 
 type cookieFilterFn func(cookie *http.Cookie) bool
 
+// CookieNames returns a string array with names of cookies given a cookie array
 func CookieNames(cookies []*http.Cookie) []string {
 	names := []string{}
 	for _, cookie := range cookies {
@@ -26,6 +27,7 @@ func CookieNames(cookies []*http.Cookie) []string {
 	return names
 }
 
+// ExpireCookiesMatching expires all cookies that evaluates `expire` function into true
 func ExpireCookiesMatching(w http.ResponseWriter, r *http.Request, expire cookieFilterFn) {
 	for _, cookie := range r.Cookies() {
 		if expire(cookie) {
@@ -35,19 +37,24 @@ func ExpireCookiesMatching(w http.ResponseWriter, r *http.Request, expire cookie
 	}
 }
 
+// ExpireCookie expires a given cookie
 func ExpireCookie(w http.ResponseWriter, c *http.Cookie) {
 	c.Expires = time.Unix(0, 0)
 	http.SetCookie(w, c)
 }
 
+// IsSessionCookie returns true if given cookie was set to manage jenkins session
 func IsSessionCookie(c *http.Cookie) bool {
 	return strings.HasPrefix(c.Name, SessionCookie)
 }
 
+// IsIdledCookie returns true if a given cookie was set to tell if jenkins is running or not
 func IsIdledCookie(c *http.Cookie) bool {
 	return c.Name == CookieJenkinsIdled
 }
 
+// IsSessionOrIdledCookie return true if given cookie was either set to manage jenkins session
+// or to tell if jenkins is running or not
 func IsSessionOrIdledCookie(c *http.Cookie) bool {
 	return IsSessionCookie(c) || IsIdledCookie(c)
 }
@@ -56,6 +63,8 @@ func anyCookie(_ *http.Cookie) bool {
 	return true
 }
 
+// SetIdledCookie set a cookie to indicate that jenkins is idled for namespace stored
+// in cache with cookie value as cache key
 func SetIdledCookie(w http.ResponseWriter) string {
 	c := &http.Cookie{}
 	c.Name = CookieJenkinsIdled

--- a/internal/proxy/cookies/cookies.go
+++ b/internal/proxy/cookies/cookies.go
@@ -1,10 +1,11 @@
-package proxy
+package cookiesutil
 
 import (
-	"github.com/satori/go.uuid"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/satori/go.uuid"
 )
 
 const (
@@ -17,7 +18,7 @@ const (
 
 type cookieFilterFn func(cookie *http.Cookie) bool
 
-func cookieNames(cookies []*http.Cookie) []string {
+func CookieNames(cookies []*http.Cookie) []string {
 	names := []string{}
 	for _, cookie := range cookies {
 		names = append(names, cookie.Name)
@@ -25,37 +26,37 @@ func cookieNames(cookies []*http.Cookie) []string {
 	return names
 }
 
-func expireCookiesMatching(w http.ResponseWriter, r *http.Request, expire cookieFilterFn) {
+func ExpireCookiesMatching(w http.ResponseWriter, r *http.Request, expire cookieFilterFn) {
 	for _, cookie := range r.Cookies() {
 		if expire(cookie) {
-			expireCookie(w, cookie)
+			ExpireCookie(w, cookie)
 		}
 		http.SetCookie(w, cookie)
 	}
 }
 
-func expireCookie(w http.ResponseWriter, c *http.Cookie) {
+func ExpireCookie(w http.ResponseWriter, c *http.Cookie) {
 	c.Expires = time.Unix(0, 0)
 	http.SetCookie(w, c)
 }
 
-func isSessionCookie(c *http.Cookie) bool {
+func IsSessionCookie(c *http.Cookie) bool {
 	return strings.HasPrefix(c.Name, SessionCookie)
 }
 
-func isIdledCookie(c *http.Cookie) bool {
+func IsIdledCookie(c *http.Cookie) bool {
 	return c.Name == CookieJenkinsIdled
 }
 
-func isSessionOrIdledCookie(c *http.Cookie) bool {
-	return isSessionCookie(c) || isIdledCookie(c)
+func IsSessionOrIdledCookie(c *http.Cookie) bool {
+	return IsSessionCookie(c) || IsIdledCookie(c)
 }
 
 func anyCookie(_ *http.Cookie) bool {
 	return true
 }
 
-func setIdledCookie(w http.ResponseWriter) string {
+func SetIdledCookie(w http.ResponseWriter) string {
 	c := &http.Cookie{}
 	c.Name = CookieJenkinsIdled
 	c.Value = uuid.NewV4().String()
@@ -63,13 +64,13 @@ func setIdledCookie(w http.ResponseWriter) string {
 	return c.Value
 }
 
-// set all cookies to w and returns the session cookie if it exists
-func setJenkinsCookies(w http.ResponseWriter, cookies []*http.Cookie) *http.Cookie {
+// SetJenkinsCookies sets all cookies to w and returns the session cookie if it exists
+func SetJenkinsCookies(w http.ResponseWriter, cookies []*http.Cookie) *http.Cookie {
 	var jsessionCookie *http.Cookie
 
 	for _, cookie := range cookies {
 		http.SetCookie(w, cookie)
-		if isSessionCookie(cookie) {
+		if IsSessionCookie(cookie) {
 			jsessionCookie = cookie
 		}
 	}

--- a/internal/proxy/cookies/cookies.go
+++ b/internal/proxy/cookies/cookies.go
@@ -33,7 +33,6 @@ func ExpireCookiesMatching(w http.ResponseWriter, r *http.Request, expire cookie
 		if expire(cookie) {
 			ExpireCookie(w, cookie)
 		}
-		http.SetCookie(w, cookie)
 	}
 }
 

--- a/internal/proxy/cookieutil/cookieutil.go
+++ b/internal/proxy/cookieutil/cookieutil.go
@@ -1,4 +1,4 @@
-package cookiesutil
+package cookieutil
 
 import (
 	"net/http"
@@ -34,6 +34,18 @@ func ExpireCookiesMatching(w http.ResponseWriter, r *http.Request, expire cookie
 			ExpireCookie(w, cookie)
 		}
 	}
+}
+
+// ExpireCookiesMatching expires all cookies that evaluates `expire` function into true
+func Filter(cookies []*http.Cookie, filter cookieFilterFn) []*http.Cookie {
+	filtered := []*http.Cookie{}
+
+	for _, cookie := range cookies {
+		if filter(cookie) {
+			filtered = append(filtered, cookie)
+		}
+	}
+	return filtered
 }
 
 // ExpireCookie expires a given cookie

--- a/internal/proxy/cookieutil/cookieutil.go
+++ b/internal/proxy/cookieutil/cookieutil.go
@@ -36,7 +36,7 @@ func ExpireCookiesMatching(w http.ResponseWriter, r *http.Request, expire cookie
 	}
 }
 
-// ExpireCookiesMatching expires all cookies that evaluates `expire` function into true
+// Filter returns all cookies that evaluates `filter` function into true
 func Filter(cookies []*http.Cookie, filter cookieFilterFn) []*http.Cookie {
 	filtered := []*http.Cookie{}
 

--- a/internal/proxy/github.go
+++ b/internal/proxy/github.go
@@ -152,12 +152,20 @@ func (p *Proxy) ProcessBuffer() {
 
 					nsLogger.WithFields(log.Fields{"repository": gh.Repository.CloneURL}).Info("Retrying request")
 					namespace, err := p.getUserWithRetry(gh.Repository.CloneURL, proxyLogger, defaultRetry)
+					if err != nil {
+						log.Error(err)
+						break
+					}
 					pci := CacheItem{
 						NS:         namespace.Name,
 						ClusterURL: namespace.ClusterURL,
 					}
 
 					jenkins, _, err := GetJenkins(p.clusters, &pci, p.idler, p.tenant, "", nsLogger)
+					if err != nil {
+						log.Error(err)
+						break
+					}
 
 					state, err := jenkins.State()
 					if err != nil {

--- a/internal/proxy/github.go
+++ b/internal/proxy/github.go
@@ -70,7 +70,7 @@ func (p *Proxy) handleGitHubRequest(w http.ResponseWriter, r *http.Request, requ
 
 	nsLogger.WithFields(log.Fields{"cluster": pci.ClusterURL, "repository": gh.Repository.CloneURL}).Info("Processing GitHub request ")
 
-	route, scheme, err := p.constructRoute(namespace.ClusterURL, namespace.Name)
+	route, scheme, err := constructRoute(p.clusters, namespace.ClusterURL, namespace.Name)
 	if err != nil {
 		p.HandleError(w, err, requestLogEntry)
 		return

--- a/internal/proxy/jenkins.go
+++ b/internal/proxy/jenkins.go
@@ -44,7 +44,11 @@ func GetJenkins(clusters map[string]string,
 		return &Jenkins{}, "", err
 	}
 
-	uid, err := auth.DefaultClient().UIDFromToken(tokenJSON.AccessToken)
+	authClient, err := auth.DefaultClient()
+	if err != nil {
+		return &Jenkins{}, "", err
+	}
+	uid, err := authClient.UIDFromToken(tokenJSON.AccessToken)
 	if err != nil {
 		return &Jenkins{}, "", err
 	}

--- a/internal/proxy/jenkins.go
+++ b/internal/proxy/jenkins.go
@@ -33,10 +33,20 @@ type Jenkins struct {
 
 // GetJenkins returns an intance of Jenkins struct
 func GetJenkins(clusters map[string]string,
+	pci *CacheItem,
 	idler clients.IdlerService,
 	tenant clients.TenantService,
 	tokenData string,
 	logger *log.Entry) (*Jenkins, string, error) {
+
+	if pci != nil {
+		return &Jenkins{
+			info:   *pci,
+			idler:  idler,
+			tenant: tenant,
+			logger: logger,
+		}, "", nil
+	}
 
 	tokenJSON := &auth.TokenJSON{}
 	err := json.Unmarshal([]byte(tokenData), tokenJSON)
@@ -70,11 +80,8 @@ func GetJenkins(clusters map[string]string,
 		return &Jenkins{}, osioToken, err
 	}
 
-	//Prepare an item for proxyCache - Jenkins info and OSO token
-	pci := NewCacheItem(namespace.Name, scheme, route, namespace.ClusterURL)
-
 	return &Jenkins{
-		info:   pci,
+		info:   NewCacheItem(namespace.Name, scheme, route, namespace.ClusterURL),
 		idler:  idler,
 		tenant: tenant,
 		logger: logger,

--- a/internal/proxy/jenkins.go
+++ b/internal/proxy/jenkins.go
@@ -145,13 +145,3 @@ func (j *Jenkins) Start() (state clients.PodState, code int, err error) {
 	}
 	return state, code, nil
 }
-
-// constructRoute returns Jenkins route based on a specific pattern
-func constructRoute(clusters map[string]string, clusterURL string, ns string) (string, string, error) {
-	appSuffix := clusters[clusterURL]
-	if len(appSuffix) == 0 {
-		return "", "", fmt.Errorf("could not find entry for cluster %s", clusterURL)
-	}
-	route := fmt.Sprintf("jenkins-%s.%s", ns, clusters[clusterURL])
-	return route, "https", nil
-}

--- a/internal/proxy/jenkins.go
+++ b/internal/proxy/jenkins.go
@@ -1,0 +1,146 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/auth"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+	log "github.com/sirupsen/logrus"
+)
+
+// JenkinsService talks to wit service, auth service, tenant service and
+// various jenkins instances in order to perform task such as starting
+// a jenkins, logging into one, get information for a jenkins instance
+// such as its url, which namespace it belongs to, which cluster it
+// belongs to etc
+type JenkinsService interface {
+	Info(tokenData string) (CacheItem, string, error)
+	Login(pci CacheItem, osoToken string) (int, []*http.Cookie, error)
+	State(ns string, clusterURL string) (clients.PodState, error)
+	Start(ns string, clusterURL string) (state clients.PodState, code int, err error)
+}
+
+// Jenkins implements Jenkins interface
+type Jenkins struct {
+	clusters map[string]string
+
+	idler  clients.IdlerService
+	tenant clients.TenantService
+
+	logger *log.Entry
+}
+
+// NewJenkins returns an intance of Jenkins struct
+func NewJenkins(clusters map[string]string, idler clients.IdlerService, tenant clients.TenantService, logger *log.Entry) *Jenkins {
+	return &Jenkins{
+		clusters: clusters,
+		idler:    idler,
+		tenant:   tenant,
+		logger:   logger,
+	}
+}
+
+// Info gets you proxy cache and OSIO token for a user to which given
+// token json belongs
+func (jenkins *Jenkins) Info(tokenData string) (CacheItem, string, error) {
+	tokenJSON := &auth.TokenJSON{}
+	err := json.Unmarshal([]byte(tokenData), tokenJSON)
+	if err != nil {
+		return CacheItem{}, "", err
+	}
+
+	uid, err := auth.DefaultClient().UIDFromToken(tokenJSON.AccessToken)
+	if err != nil {
+		return CacheItem{}, "", err
+	}
+
+	ti, err := jenkins.tenant.GetTenantInfo(uid)
+	if err != nil {
+		return CacheItem{}, "", err
+	}
+	osioToken := tokenJSON.AccessToken
+
+	namespace, err := clients.GetNamespaceByType(ti, ServiceName)
+	if err != nil {
+		return CacheItem{}, osioToken, err
+	}
+
+	jenkins.logger.WithField("ns", namespace.Name).Debug("Extracted information from token")
+	route, scheme, err := jenkins.constructRoute(namespace.ClusterURL, namespace.Name)
+	if err != nil {
+		return CacheItem{}, osioToken, err
+	}
+
+	//Prepare an item for proxyCache - Jenkins info and OSO token
+	pci := NewCacheItem(namespace.Name, scheme, route, namespace.ClusterURL)
+
+	return pci, osioToken, nil
+}
+
+//Login to Jenkins with OSO token to get cookies
+func (jenkins *Jenkins) Login(pci CacheItem, osoToken string) (int, []*http.Cookie, error) {
+
+	jenkinsURL := fmt.Sprintf("%s://%s/securityRealm/commenceLogin?from=%%2F", pci.Scheme, pci.Route)
+
+	req, _ := http.NewRequest("GET", jenkinsURL, nil)
+	if len(osoToken) > 0 {
+		jenkins.logger.WithField("ns", pci.NS).Infof("Jenkins login for %s", jenkinsURL)
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", osoToken))
+	} else {
+		jenkins.logger.WithField("ns", pci.NS).Infof("Accessing Jenkins route %s", jenkinsURL)
+	}
+	c := http.DefaultClient
+	resp, err := c.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, resp.Cookies(), err
+}
+
+// State returns state of Jenkins associated with given namespace
+func (jenkins *Jenkins) State(ns string, clusterURL string) (clients.PodState, error) {
+	return jenkins.idler.State(ns, clusterURL)
+}
+
+// Start unidles Jenkins only if it is idled and returns the
+// state of the pod, the http status of calling unidle, and error if any
+func (jenkins *Jenkins) Start(ns string, clusterURL string) (state clients.PodState, code int, err error) {
+	// Assume pods are starting and unidle only if it is in "idled" state
+	code = http.StatusAccepted
+	//nsLogger := log.WithFields(log.Fields{"ns": ns, "cluster": clusterURL})
+
+	state, err = jenkins.idler.State(ns, clusterURL)
+	if err != nil {
+		return
+	}
+	jenkins.logger.Infof("state : %q", state)
+
+	if state == clients.Idled {
+		// Unidle only if needed
+		jenkins.logger.Infof("Unidling jenkins")
+		if code, err = jenkins.idler.UnIdle(ns, clusterURL); err != nil {
+			return
+		}
+	}
+	if code == http.StatusOK {
+		// XHR relies on 202 to retry and 200 to stop retrying and reload
+		// since we just started jenkins pods, change the code to 202 so
+		// that it retries
+		// SEE: static/html/index.html
+		code = http.StatusAccepted
+	}
+	return state, code, nil
+}
+
+// constructRoute returns Jenkins route based on a specific pattern
+func (jenkins *Jenkins) constructRoute(clusterURL string, ns string) (string, string, error) {
+	appSuffix := jenkins.clusters[clusterURL]
+	if len(appSuffix) == 0 {
+		return "", "", fmt.Errorf("could not find entry for cluster %s", clusterURL)
+	}
+	route := fmt.Sprintf("jenkins-%s.%s", ns, jenkins.clusters[clusterURL])
+	return route, "https", nil
+}

--- a/internal/proxy/jenkins.go
+++ b/internal/proxy/jenkins.go
@@ -44,7 +44,7 @@ func GetJenkins(clusters map[string]string,
 			info:   *pci,
 			idler:  idler,
 			tenant: tenant,
-			logger: logger,
+			logger: logger.WithFields(log.Fields{"ns": pci.NS, "cluster": pci.ClusterURL}),
 		}, "", nil
 	}
 
@@ -84,7 +84,7 @@ func GetJenkins(clusters map[string]string,
 		info:   NewCacheItem(namespace.Name, scheme, route, namespace.ClusterURL),
 		idler:  idler,
 		tenant: tenant,
-		logger: logger,
+		logger: logger.WithFields(log.Fields{"ns": namespace.Name, "cluster": namespace.ClusterURL}),
 	}, osioToken, nil
 }
 
@@ -121,7 +121,6 @@ func (j *Jenkins) Start() (state clients.PodState, code int, err error) {
 	code = http.StatusAccepted
 	ns := j.info.NS
 	clusterURL := j.info.ClusterURL
-	//nsLogger := log.WithFields(log.Fields{"ns": ns, "cluster": clusterURL})
 
 	state, err = j.idler.State(ns, clusterURL)
 	if err != nil {

--- a/internal/proxy/mock_proxy.go
+++ b/internal/proxy/mock_proxy.go
@@ -1,0 +1,29 @@
+package proxy
+
+import (
+	"time"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/auth"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/testutils/mock"
+	cache "github.com/patrickmn/go-cache"
+)
+
+// NewMockProxy returns an instance of proxy object that uses mocked dependency services
+func NewMockProxy(jenkinsState clients.PodState) *Proxy {
+
+	if jenkinsState == "" {
+		jenkinsState = clients.Idled
+	}
+	auth.SetDefaultClient(auth.NewMockAuth("http://authURL"))
+
+	return &Proxy{
+		tenant: &mock.Tenant{},
+		idler:  mock.NewMockIdler("", jenkinsState, false),
+		clusters: map[string]string{
+			"Valid_OpenShift_API_URL": "test_route",
+		},
+		ProxyCache: cache.New(15*time.Minute, 10*time.Minute),
+		redirect:   "http://redirect",
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -44,7 +44,7 @@ type Proxy struct {
 	ProxyCache       *cache.Cache
 	visitLock        *sync.Mutex
 	bufferCheckSleep time.Duration
-	tenant           *clients.Tenant
+	tenant           clients.TenantService
 	wit              clients.WIT
 	idler            clients.IdlerService
 	//redirect is a base URL of the proxy
@@ -60,7 +60,7 @@ type Proxy struct {
 // NewProxy creates an instance of Proxy client
 func NewProxy(
 	idler clients.IdlerService,
-	tenant *clients.Tenant,
+	tenant clients.TenantService,
 	wit clients.WIT,
 	storageService storage.Store,
 	config configuration.Configuration,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -45,7 +45,7 @@ type Proxy struct {
 	visitLock        *sync.Mutex
 	bufferCheckSleep time.Duration
 	tenant           clients.TenantService
-	wit              clients.WIT
+	wit              clients.WITService
 	idler            clients.IdlerService
 	//redirect is a base URL of the proxy
 	redirect        string
@@ -61,7 +61,7 @@ type Proxy struct {
 func NewProxy(
 	idler clients.IdlerService,
 	tenant clients.TenantService,
-	wit clients.WIT,
+	wit clients.WITService,
 	storageService storage.Store,
 	config configuration.Configuration,
 	clusters map[string]string) (Proxy, error) {
@@ -72,6 +72,7 @@ func NewProxy(
 		visitLock:        &sync.Mutex{},
 		tenant:           tenant,
 		wit:              wit,
+		idler:            idler,
 		bufferCheckSleep: 30 * time.Second,
 		redirect:         config.GetRedirectURL(),
 		responseTimeout:  config.GetGatewayTimeout(),

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 
 	"hash/fnv"
 
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/configuration"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/metric"
 	cookiesutil "github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy/cookies"
@@ -43,11 +44,11 @@ type Proxy struct {
 	ProxyCache       *cache.Cache
 	visitLock        *sync.Mutex
 	bufferCheckSleep time.Duration
-	//tenant           *clients.Tenant
-	//wit              clients.WIT
-	//idler            clients.IdlerService
-	codebase CodebaseService
-	jenkins  JenkinsService
+	tenant           *clients.Tenant
+	wit              clients.WIT
+	idler            clients.IdlerService
+	//codebase CodebaseService
+	//jenkins  JenkinsService
 	//redirect is a base URL of the proxy
 	redirect        string
 	responseTimeout time.Duration
@@ -60,7 +61,9 @@ type Proxy struct {
 
 // NewProxy creates an instance of Proxy client
 func NewProxy(
-	codebase CodebaseService, jenkins JenkinsService,
+	idler clients.IdlerService,
+	tenant *clients.Tenant,
+	wit clients.WIT,
 	storageService storage.Store,
 	config configuration.Configuration,
 	clusters map[string]string) (Proxy, error) {
@@ -69,10 +72,10 @@ func NewProxy(
 		TenantCache: cache.New(30*time.Minute, 40*time.Minute),
 		ProxyCache:  cache.New(15*time.Minute, 10*time.Minute),
 		visitLock:   &sync.Mutex{},
-		//tenant:           tenant,
-		//wit:              wit,
-		codebase:         codebase,
-		jenkins:          jenkins,
+		tenant:      tenant,
+		wit:         wit,
+		//codebase:         codebase,
+		//jenkins:          jenkins,
 		bufferCheckSleep: 30 * time.Second,
 		redirect:         config.GetRedirectURL(),
 		responseTimeout:  config.GetGatewayTimeout(),

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -9,7 +9,6 @@ import (
 
 	"hash/fnv"
 
-	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/configuration"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/metric"
 	cookiesutil "github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy/cookies"
@@ -44,10 +43,11 @@ type Proxy struct {
 	ProxyCache       *cache.Cache
 	visitLock        *sync.Mutex
 	bufferCheckSleep time.Duration
-	tenant           *clients.Tenant
-	wit              clients.WIT
-	idler            clients.IdlerService
-
+	//tenant           *clients.Tenant
+	//wit              clients.WIT
+	//idler            clients.IdlerService
+	codebase CodebaseService
+	jenkins  JenkinsService
 	//redirect is a base URL of the proxy
 	redirect        string
 	responseTimeout time.Duration
@@ -60,18 +60,19 @@ type Proxy struct {
 
 // NewProxy creates an instance of Proxy client
 func NewProxy(
-	tenant *clients.Tenant, wit clients.WIT, idler clients.IdlerService,
+	codebase CodebaseService, jenkins JenkinsService,
 	storageService storage.Store,
 	config configuration.Configuration,
 	clusters map[string]string) (Proxy, error) {
 
 	p := Proxy{
-		TenantCache:      cache.New(30*time.Minute, 40*time.Minute),
-		ProxyCache:       cache.New(15*time.Minute, 10*time.Minute),
-		visitLock:        &sync.Mutex{},
-		tenant:           tenant,
-		wit:              wit,
-		idler:            idler,
+		TenantCache: cache.New(30*time.Minute, 40*time.Minute),
+		ProxyCache:  cache.New(15*time.Minute, 10*time.Minute),
+		visitLock:   &sync.Mutex{},
+		//tenant:           tenant,
+		//wit:              wit,
+		codebase:         codebase,
+		jenkins:          jenkins,
 		bufferCheckSleep: 30 * time.Second,
 		redirect:         config.GetRedirectURL(),
 		responseTimeout:  config.GetGatewayTimeout(),

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/configuration"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/metric"
-	cookiesutil "github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy/cookies"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy/cookies"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy/reverseproxy"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/storage"
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/util/logging"
@@ -69,13 +69,11 @@ func NewProxy(
 	clusters map[string]string) (Proxy, error) {
 
 	p := Proxy{
-		TenantCache: cache.New(30*time.Minute, 40*time.Minute),
-		ProxyCache:  cache.New(15*time.Minute, 10*time.Minute),
-		visitLock:   &sync.Mutex{},
-		tenant:      tenant,
-		wit:         wit,
-		//codebase:         codebase,
-		//jenkins:          jenkins,
+		TenantCache:      cache.New(30*time.Minute, 40*time.Minute),
+		ProxyCache:       cache.New(15*time.Minute, 10*time.Minute),
+		visitLock:        &sync.Mutex{},
+		tenant:           tenant,
+		wit:              wit,
 		bufferCheckSleep: 30 * time.Second,
 		redirect:         config.GetRedirectURL(),
 		responseTimeout:  config.GetGatewayTimeout(),

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -47,8 +47,6 @@ type Proxy struct {
 	tenant           *clients.Tenant
 	wit              clients.WIT
 	idler            clients.IdlerService
-	//codebase CodebaseService
-	//jenkins  JenkinsService
 	//redirect is a base URL of the proxy
 	redirect        string
 	responseTimeout time.Duration

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -221,16 +221,6 @@ func (p *Proxy) recordStatistics(ns string, la int64, lbf int64) (err error) {
 	return
 }
 
-//constructRoute returns Jenkins route based on a specific pattern
-func (p *Proxy) constructRoute(clusterURL string, ns string) (string, string, error) {
-	appSuffix := p.clusters[clusterURL]
-	if len(appSuffix) == 0 {
-		return "", "", fmt.Errorf("could not find entry for cluster %s", clusterURL)
-	}
-	route := fmt.Sprintf("jenkins-%s.%s", ns, p.clusters[clusterURL])
-	return route, "https", nil
-}
-
 func cleanupSession(w http.ResponseWriter, cookies []*http.Cookie, p *Proxy) {
 	for _, cookie := range cookies {
 		if cookiesutil.IsSessionCookie(cookie) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -158,7 +158,7 @@ func (p *Proxy) Handle(w http.ResponseWriter, r *http.Request) {
 	rp.ServeHTTP(w, r)
 
 	if !rp.IsValidSession {
-		cleanUpSession(w, r.Cookies(), p)
+		cleanupSession(w, r.Cookies(), p)
 	}
 }
 
@@ -230,7 +230,7 @@ func (p *Proxy) constructRoute(clusterURL string, ns string) (string, string, er
 	return route, "https", nil
 }
 
-func cleanUpSession(w http.ResponseWriter, cookies []*http.Cookie, p *Proxy) {
+func cleanupSession(w http.ResponseWriter, cookies []*http.Cookie, p *Proxy) {
 	for _, cookie := range cookies {
 		if cookiesutil.IsSessionCookie(cookie) {
 			var pci CacheItem
@@ -245,7 +245,7 @@ func cleanUpSession(w http.ResponseWriter, cookies []*http.Cookie, p *Proxy) {
 			}
 
 			cookiesutil.ExpireCookie(w, cookie)
-			proxyLogger.Infof("cookie is OLD; expiring the cookie, cookie_name: %s, namespace: %s", cookie.Name)
+			proxyLogger.Infof("cookie is OLD; expiring the cookie, cookie_name: %s, namespace: %s", cookie.Name, pci.NS)
 
 			// There could be multiple cookies starting with JSESSIONID.
 			// We need to check them all

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,22 +1,15 @@
 package proxy
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
 	"errors"
 
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
-	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy/reverseproxy"
-	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/testutils/mock"
 	cache "github.com/patrickmn/go-cache"
-	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	gock "gopkg.in/h2non/gock.v1"
 )
 
 type mockWit struct {
@@ -48,71 +41,4 @@ func TestGetUserWithRetry(t *testing.T) {
 	_, err := p.getUserWithRetry("http://test", logEntry, numberofretry)
 	assert.Error(t, err, "Faker")
 	assert.Equal(t, numberofretry, wit.testCounter)
-}
-
-func TestValidateSession(t *testing.T) {
-	// Reverse proxy checks the session validity on recieving status Forbidden
-	// from jenkins
-	defer gock.Off()
-
-	gock.New("https://jenkinsHost").
-		Get("/path").
-		Reply(http.StatusForbidden)
-
-	gock.New("https://jenkinsHost").
-		Get("").
-		Reply(http.StatusForbidden)
-
-	config := mock.NewConfig()
-
-	p := NewMockProxy(clients.Running)
-	cookieVal := uuid.NewV4().String()
-	info := CacheItem{
-		ClusterURL: "Valid_OpenShift_API_URL",
-		NS:         "namespace-jenkins",
-		Scheme:     "https",
-		Route:      "https://jenkinsHost",
-	}
-	p.ProxyCache.SetDefault(cookieVal, info)
-
-	req := httptest.NewRequest("GET", "https://jenkinsHost/path", nil)
-	req.AddCookie(&http.Cookie{
-		Name:  "JSESSIONID." + uuid.NewV4().String(),
-		Value: cookieVal,
-	})
-
-	w := httptest.NewRecorder()
-
-	rp := reverseproxy.NewReverseProxy(
-		//*req.URL,
-		url.URL{
-			Scheme: "https",
-			Host:   "proxy",
-			Path:   "/path",
-		},
-		config.GetGatewayTimeout(),
-		p.OnError,
-
-		log.WithFields(log.Fields{"component": "testing"}),
-	)
-
-	// Session cookie exists and there a cache item in proxy cache
-	// with key as the cookie value, but session has expired from jenkins
-	// side. Proxy doesn't know about this just yet.
-	// Jenkins would return status forbidden on this, we expire cookie
-	// and delete the cache
-
-	_, ok := p.ProxyCache.Get(cookieVal)
-	assert.True(t, ok, "CacheItem exists")
-	rp.ServeHTTP(w, req)
-	_, ok = p.ProxyCache.Get(cookieVal)
-	assert.False(t, ok, "CacheItem has been deleted")
-
-	setCookieHeaders := w.Header()["Set-Cookie"]
-	assert.Equal(t, 1, len(setCookieHeaders))
-	assert.Contains(t, setCookieHeaders[0], "JSESSIONID")
-	assert.Contains(t, setCookieHeaders[0], "Expires")
-
-	// Redirects to the redirect url
-	assert.Equal(t, w.Header().Get("Location"), "https://proxy/path")
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,15 +1,22 @@
 package proxy
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"errors"
 
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/proxy/reverseproxy"
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/testutils/mock"
 	cache "github.com/patrickmn/go-cache"
+	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 type mockWit struct {
@@ -41,4 +48,71 @@ func TestGetUserWithRetry(t *testing.T) {
 	_, err := p.getUserWithRetry("http://test", logEntry, numberofretry)
 	assert.Error(t, err, "Faker")
 	assert.Equal(t, numberofretry, wit.testCounter)
+}
+
+func TestValidateSession(t *testing.T) {
+	// Reverse proxy checks the session validity on recieving status Forbidden
+	// from jenkins
+	defer gock.Off()
+
+	gock.New("https://jenkinsHost").
+		Get("/path").
+		Reply(http.StatusForbidden)
+
+	gock.New("https://jenkinsHost").
+		Get("").
+		Reply(http.StatusForbidden)
+
+	config := mock.NewConfig()
+
+	p := NewMockProxy(clients.Running)
+	cookieVal := uuid.NewV4().String()
+	info := CacheItem{
+		ClusterURL: "Valid_OpenShift_API_URL",
+		NS:         "namespace-jenkins",
+		Scheme:     "https",
+		Route:      "https://jenkinsHost",
+	}
+	p.ProxyCache.SetDefault(cookieVal, info)
+
+	req := httptest.NewRequest("GET", "https://jenkinsHost/path", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "JSESSIONID." + uuid.NewV4().String(),
+		Value: cookieVal,
+	})
+
+	w := httptest.NewRecorder()
+
+	rp := reverseproxy.NewReverseProxy(
+		//*req.URL,
+		url.URL{
+			Scheme: "https",
+			Host:   "proxy",
+			Path:   "/path",
+		},
+		config.GetGatewayTimeout(),
+		p.OnError,
+
+		log.WithFields(log.Fields{"component": "testing"}),
+	)
+
+	// Session cookie exists and there a cache item in proxy cache
+	// with key as the cookie value, but session has expired from jenkins
+	// side. Proxy doesn't know about this just yet.
+	// Jenkins would return status forbidden on this, we expire cookie
+	// and delete the cache
+
+	_, ok := p.ProxyCache.Get(cookieVal)
+	assert.True(t, ok, "CacheItem exists")
+	rp.ServeHTTP(w, req)
+	_, ok = p.ProxyCache.Get(cookieVal)
+	assert.False(t, ok, "CacheItem has been deleted")
+
+	setCookieHeaders := w.Header()["Set-Cookie"]
+	assert.Equal(t, 1, len(setCookieHeaders))
+	assert.Contains(t, setCookieHeaders[0], "JSESSIONID")
+	assert.Contains(t, setCookieHeaders[0], "Expires")
+
+	// Redirects to the redirect url
+	assert.Equal(t, w.Header().Get("Location"), "https://proxy/path")
 }

--- a/internal/proxy/reverseproxy/response.go
+++ b/internal/proxy/reverseproxy/response.go
@@ -48,6 +48,12 @@ func (rr *responseRecorder) WriteHeader(code int) {
 		return
 	}
 
+	if code == http.StatusForbidden {
+		rr.err = fmt.Errorf("forbidden error: %d", code)
+		rr.log.Warnf("Error Forbidden WriteHeader %v - SKIPPED", code)
+		return
+	}
+
 	rr.log.Infof("WriteHeader %d - OK", code)
 	rr.ResponseWriter.WriteHeader(code)
 }

--- a/internal/proxy/reverseproxy/reverseproxy.go
+++ b/internal/proxy/reverseproxy/reverseproxy.go
@@ -66,17 +66,18 @@ func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	if rr.err != nil {
 		logger.Warnf("Error %q - code: %d", rr.err, rr.statusCode)
-
-		if rr.statusCode == http.StatusForbidden {
-			var err error
-			rp.IsValidSession, err = checkSessionValidity(req)
-			if err != nil {
-				logger.Error(err)
-			}
-		}
-
-		// http.Redirect(rw, req, rp.RedirectURL.String(), http.StatusFound)
+		http.Redirect(rw, req, rp.RedirectURL.String(), http.StatusFound)
 	}
+
+	if rr.statusCode == http.StatusForbidden {
+		var err error
+		rp.IsValidSession, err = checkSessionValidity(req)
+		if err != nil {
+			logger.Error(err)
+		}
+		http.Redirect(rw, req, rp.RedirectURL.String(), http.StatusFound)
+	}
+
 }
 
 func checkSessionValidity(req *http.Request) (bool, error) {

--- a/internal/proxy/reverseproxy/reverseproxy.go
+++ b/internal/proxy/reverseproxy/reverseproxy.go
@@ -60,9 +60,8 @@ func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if rr.err != nil {
 		logger.Warnf("Error %q - code: %d", rr.err, rr.statusCode)
 
-		err := rp.OnError(rw, req, rr.statusCode)
-		if err != nil {
-			logger.Error(err)
+		if err := rp.OnError(rw, req, rr.statusCode); err != nil {
+			logger.Errorf("onError returned error: %s", err)
 		}
 
 		http.Redirect(rw, req, rp.RedirectURL.String(), http.StatusFound)

--- a/internal/proxy/reverseproxy/reverseproxy.go
+++ b/internal/proxy/reverseproxy/reverseproxy.go
@@ -65,18 +65,16 @@ func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	if rr.err != nil {
 		logger.Warnf("Error %q - code: %d", rr.err, rr.statusCode)
-		http.Redirect(rw, req, rp.RedirectURL.String(), http.StatusFound)
-	}
 
-	if rr.statusCode >= 400 && rr.statusCode < 500 {
-		var err error
-		rp.IsValidSession, err = checkSessionValidity(req)
-		if err != nil {
-			logger.Error(err)
+		if rr.statusCode == http.StatusForbidden {
+			var err error
+			rp.IsValidSession, err = checkSessionValidity(req)
+			if err != nil {
+				logger.Error(err)
+			}
 		}
 		http.Redirect(rw, req, rp.RedirectURL.String(), http.StatusFound)
 	}
-
 }
 
 func checkSessionValidity(req *http.Request) (bool, error) {

--- a/internal/proxy/reverseproxy/reverseproxy.go
+++ b/internal/proxy/reverseproxy/reverseproxy.go
@@ -67,7 +67,6 @@ func (rp *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		logger.Warnf("Error %q - code: %d", rr.err, rr.statusCode)
 
 		if rr.statusCode == http.StatusForbidden {
-			fmt.Println("YES HERE")
 			var err error
 			rp.IsValidSession, err = checkSessionValidity(req, rp)
 			if err != nil {

--- a/internal/proxy/reverseproxy/reverseproxy_test.go
+++ b/internal/proxy/reverseproxy/reverseproxy_test.go
@@ -104,7 +104,7 @@ func TestReverseProxy(t *testing.T) {
 	assert.Equal(t, res.Cookies()[0].Name, "flavor", "Cookie setting failed")
 
 	bodyBytes, _ := ioutil.ReadAll(res.Body)
-	assert.Equal(t, string(bodyBytes), backendResponse, "unexpected response body")
+	assert.Equal(t, backendResponse, string(bodyBytes), "unexpected response body")
 
 	assert.Equal(t, res.Trailer.Get("X-Trailer"), "trailer_value", "Trailer(X-Trailer)")
 	assert.Equal(t, res.Trailer.Get("X-Unannounced-Trailer"),

--- a/internal/proxy/reverseproxy/reverseproxy_test.go
+++ b/internal/proxy/reverseproxy/reverseproxy_test.go
@@ -23,7 +23,7 @@ func TestReverseProxy(t *testing.T) {
 		// if the "mode" is "hangup"
 		if r.Method == "GET" && r.FormValue("mode") == "hangup" {
 			if retries < 5 {
-				// NOTE Hijack results in calling  the handlerfunc again for the
+				// NOTE Hijack results in calling the handlerfunc again for the
 				// first time so for the first time retry will be incremented to 2
 				retries++
 				c, _, _ := w.(http.Hijacker).Hijack()

--- a/internal/proxy/ui_requests.go
+++ b/internal/proxy/ui_requests.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -37,7 +36,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 			return
 		}
 
-		pci, osioToken, err := p.processToken([]byte(tj[0]), tjLogger)
+		pci, osioToken, err := p.jenkins.Info(tj[0])
 		if err != nil {
 			p.HandleError(w, fmt.Errorf("Error processing token_json to get osio-token: %q", err), tjLogger)
 			return
@@ -58,7 +57,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 
 		// we don't care about code here since only the state of jenkins pod -
 		// running or not is what is relevant
-		state, _, err := p.startJenkins(ns, clusterURL)
+		state, _, err := p.jenkins.Start(ns, clusterURL)
 		if err != nil {
 			p.HandleError(w, fmt.Errorf("Error when starting Jenkins: %s", err), nsLogger)
 			return
@@ -85,7 +84,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 		}
 
 		// Jenkins is running at this point; login and set the jenkins cookies
-		status, jenkinsCookies, err := p.loginJenkins(pci, osoToken, nsLogger)
+		status, jenkinsCookies, err := p.jenkins.Login(pci, osoToken)
 		if err != nil {
 			p.HandleError(w, fmt.Errorf("Error when logging into jenkins: %s", err), nsLogger)
 			return
@@ -155,7 +154,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 				scLogger.Infof("Cache has Jenkins route %q in %q", pci.Route, cookie.Value)
 
 				// ensure jenkins is running
-				state, _, err := p.startJenkins(ns, pci.ClusterURL)
+				state, _, err := p.jenkins.Start(ns, pci.ClusterURL)
 				if err != nil {
 					p.HandleError(w, err, scLogger)
 					return
@@ -188,7 +187,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 				icLogger.Infof("Cache has Jenkins route %q in %q", pci.Route, cookie.Value)
 
 				needsAuth = false
-				state, code, err := p.startJenkins(ns, clusterURL)
+				state, code, err := p.jenkins.Start(ns, clusterURL)
 				if err != nil {
 					p.HandleError(w, err, icLogger)
 					return
@@ -220,7 +219,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 
 				// login is performed using "" token to only verify if jenkins is actually running
 				var statusCode int
-				statusCode, _, err = p.loginJenkins(pci, "", icLogger)
+				statusCode, _, err = p.jenkins.Login(pci, "")
 
 				if err != nil {
 					p.HandleError(w, err, icLogger)
@@ -272,6 +271,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 	return
 }
 
+/*
 func (p *Proxy) loginJenkins(pci CacheItem, osoToken string, logger *log.Entry) (int, []*http.Cookie, error) {
 	//Login to Jenkins with OSO token to get cookies
 	jenkinsURL := fmt.Sprintf("%s://%s/securityRealm/commenceLogin?from=%%2F", pci.Scheme, pci.Route)
@@ -297,7 +297,7 @@ func (p *Proxy) processToken(tokenData []byte, logger *log.Entry) (pci CacheItem
 	err = json.Unmarshal(tokenData, tokenJSON)
 	if err != nil {
 		return
-	}
+	}m
 
 	uid, err := auth.DefaultClient().UIDFromToken(tokenJSON.AccessToken)
 	if err != nil {
@@ -326,15 +326,16 @@ func (p *Proxy) processToken(tokenData []byte, logger *log.Entry) (pci CacheItem
 
 	return
 }
-
+*/
 // unidles Jenkins only if it is idled and returns the
 // state of the pod, the http status of calling unidle, and error if any
+/*
 func (p *Proxy) startJenkins(ns, clusterURL string) (state clients.PodState, code int, err error) {
 	// Assume pods are starting and unidle only if it is in "idled" state
 	code = http.StatusAccepted
 	nsLogger := log.WithFields(log.Fields{"ns": ns, "cluster": clusterURL})
 
-	state, err = p.idler.State(ns, clusterURL)
+	state, err = p.jenkins.State(ns, clusterURL)
 	if err != nil {
 		return
 	}
@@ -356,3 +357,4 @@ func (p *Proxy) startJenkins(ns, clusterURL string) (state clients.PodState, cod
 	}
 	return state, code, nil
 }
+*/

--- a/internal/proxy/ui_requests.go
+++ b/internal/proxy/ui_requests.go
@@ -36,7 +36,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 			return
 		}
 
-		jenkins, osioToken, err := GetJenkins(p.clusters, p.idler, p.tenant, tj[0], logger)
+		jenkins, osioToken, err := GetJenkins(p.clusters, nil, p.idler, p.tenant, tj[0], logger)
 		if err != nil {
 			p.HandleError(w, fmt.Errorf("Error processing token_json to get osio-token: %q", err), tjLogger)
 			return
@@ -149,7 +149,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 			pci := cacheVal.(CacheItem)
 			ns = pci.NS
 			clusterURL := pci.ClusterURL
-			jenkins, _, err := GetJenkins(nil, p.idler, p.tenant, "", cookieLogger)
+			jenkins, _, err := GetJenkins(nil, &pci, p.idler, p.tenant, "", cookieLogger)
 			if err != nil {
 				p.HandleError(w, err, cookieLogger)
 				return

--- a/internal/proxy/ui_requests.go
+++ b/internal/proxy/ui_requests.go
@@ -36,19 +36,20 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 			return
 		}
 
-		pci, osioToken, err := p.jenkins.Info(tj[0])
+		//pci, osioToken, err := p.jenkins.Info(tj[0])
+		jenkins, osioToken, err := GetJenkins(p.clusters, p.idler, p.tenant, tj[0], logger)
 		if err != nil {
 			p.HandleError(w, fmt.Errorf("Error processing token_json to get osio-token: %q", err), tjLogger)
 			return
 		}
 
-		ns = pci.NS
-		clusterURL := pci.ClusterURL
+		ns = jenkins.info.NS
+		clusterURL := jenkins.info.ClusterURL
 
 		nsLogger := tjLogger.WithFields(log.Fields{"ns": ns, "cluster": clusterURL})
 		nsLogger.Infof("found ns : %q, cluster: %q", ns, clusterURL)
 
-		osoToken, err := auth.DefaultClient().OSOTokenForCluster(pci.ClusterURL, osioToken)
+		osoToken, err := auth.DefaultClient().OSOTokenForCluster(jenkins.info.ClusterURL, osioToken)
 		if err != nil {
 			p.HandleError(w, fmt.Errorf("Error when fetching OSO token: %s", err), nsLogger)
 			return
@@ -57,7 +58,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 
 		// we don't care about code here since only the state of jenkins pod -
 		// running or not is what is relevant
-		state, _, err := p.jenkins.Start(ns, clusterURL)
+		state, _, err := jenkins.Start()
 		if err != nil {
 			p.HandleError(w, fmt.Errorf("Error when starting Jenkins: %s", err), nsLogger)
 			return
@@ -66,7 +67,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 		if state != clients.Running {
 			// Break the process if Jenkins isn't running.
 
-			nsLogger.Infof("setting idled cookie: %v ", pci)
+			nsLogger.Infof("setting idled cookie: %v ", jenkins.info)
 
 			// jenkins is idled and there could be old jsession, so delete them as
 			// it will be invalid at this point
@@ -75,7 +76,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 			// Set "idled" cookie to indicate that jenkins is idled
 			// also cache the ns & cluster for faster lookup next time
 			uuid := cookiesutil.SetIdledCookie(w)
-			p.ProxyCache.SetDefault(uuid, pci)
+			p.ProxyCache.SetDefault(uuid, jenkins.info)
 
 			// Redirect to set the idled cookied and to  get rid of token in URL
 			nsLogger.Info("Redirecting to remove token from URL")
@@ -84,7 +85,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 		}
 
 		// Jenkins is running at this point; login and set the jenkins cookies
-		status, jenkinsCookies, err := p.jenkins.Login(pci, osoToken)
+		status, jenkinsCookies, err := jenkins.Login(osoToken)
 		if err != nil {
 			p.HandleError(w, fmt.Errorf("Error when logging into jenkins: %s", err), nsLogger)
 			return
@@ -112,8 +113,8 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 		// Update proxy-cache to associate pci with the session cookie
 		// the cache so that, the subsequent request that would contain the
 		// the jession cookie can be used to lookup the cache
-		p.ProxyCache.SetDefault(jsessionCookie.Value, pci)
-		nsLogger.Infof("Cached Jenkins route %q in %q", pci.Route, jsessionCookie.Value)
+		p.ProxyCache.SetDefault(jsessionCookie.Value, jenkins.info)
+		nsLogger.Infof("Cached Jenkins route %q in %q", jenkins.info.Route, jsessionCookie.Value)
 
 		// If all good, redirect to self to remove token from url
 		nsLogger.Infof("Redirecting to %q", redirectURL)
@@ -144,6 +145,12 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 			pci := cacheVal.(CacheItem)
 			ns = pci.NS
 			clusterURL := pci.ClusterURL
+			jenkins, _, err := GetJenkins(nil, p.idler, p.tenant, "", cookieLogger)
+			if err != nil {
+				p.HandleError(w, err, cookieLogger)
+				return
+			}
+			jenkins.info = pci
 
 			nsLogger := log.WithFields(log.Fields{"ns": ns, "cluster": clusterURL, "cookie": cookie.Name})
 			nsLogger.Infof("cookie: %q is in cache", cookie.Name)
@@ -154,7 +161,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 				scLogger.Infof("Cache has Jenkins route %q in %q", pci.Route, cookie.Value)
 
 				// ensure jenkins is running
-				state, _, err := p.jenkins.Start(ns, pci.ClusterURL)
+				state, _, err := jenkins.Start()
 				if err != nil {
 					p.HandleError(w, err, scLogger)
 					return
@@ -187,7 +194,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 				icLogger.Infof("Cache has Jenkins route %q in %q", pci.Route, cookie.Value)
 
 				needsAuth = false
-				state, code, err := p.jenkins.Start(ns, clusterURL)
+				state, code, err := jenkins.Start()
 				if err != nil {
 					p.HandleError(w, err, icLogger)
 					return
@@ -219,7 +226,7 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 
 				// login is performed using "" token to only verify if jenkins is actually running
 				var statusCode int
-				statusCode, _, err = p.jenkins.Login(pci, "")
+				statusCode, _, err = jenkins.Login("")
 
 				if err != nil {
 					p.HandleError(w, err, icLogger)
@@ -270,91 +277,3 @@ func (p *Proxy) handleJenkinsUIRequest(w http.ResponseWriter, r *http.Request, l
 	}
 	return
 }
-
-/*
-func (p *Proxy) loginJenkins(pci CacheItem, osoToken string, logger *log.Entry) (int, []*http.Cookie, error) {
-	//Login to Jenkins with OSO token to get cookies
-	jenkinsURL := fmt.Sprintf("%s://%s/securityRealm/commenceLogin?from=%%2F", pci.Scheme, pci.Route)
-
-	req, _ := http.NewRequest("GET", jenkinsURL, nil)
-	if len(osoToken) > 0 {
-		logger.WithField("ns", pci.NS).Infof("Jenkins login for %s", jenkinsURL)
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", osoToken))
-	} else {
-		logger.WithField("ns", pci.NS).Infof("Accessing Jenkins route %s", jenkinsURL)
-	}
-	c := http.DefaultClient
-	resp, err := c.Do(req)
-	if err != nil {
-		return 0, nil, err
-	}
-	defer resp.Body.Close()
-	return resp.StatusCode, resp.Cookies(), err
-}
-
-func (p *Proxy) processToken(tokenData []byte, logger *log.Entry) (pci CacheItem, osioToken string, err error) {
-	tokenJSON := &auth.TokenJSON{}
-	err = json.Unmarshal(tokenData, tokenJSON)
-	if err != nil {
-		return
-	}m
-
-	uid, err := auth.DefaultClient().UIDFromToken(tokenJSON.AccessToken)
-	if err != nil {
-		return
-	}
-
-	ti, err := p.tenant.GetTenantInfo(uid)
-	if err != nil {
-		return
-	}
-	osioToken = tokenJSON.AccessToken
-
-	namespace, err := clients.GetNamespaceByType(ti, ServiceName)
-	if err != nil {
-		return
-	}
-
-	logger.WithField("ns", namespace.Name).Debug("Extracted information from token")
-	route, scheme, err := p.constructRoute(namespace.ClusterURL, namespace.Name)
-	if err != nil {
-		return
-	}
-
-	//Prepare an item for proxyCache - Jenkins info and OSO token
-	pci = NewCacheItem(namespace.Name, scheme, route, namespace.ClusterURL)
-
-	return
-}
-*/
-// unidles Jenkins only if it is idled and returns the
-// state of the pod, the http status of calling unidle, and error if any
-/*
-func (p *Proxy) startJenkins(ns, clusterURL string) (state clients.PodState, code int, err error) {
-	// Assume pods are starting and unidle only if it is in "idled" state
-	code = http.StatusAccepted
-	nsLogger := log.WithFields(log.Fields{"ns": ns, "cluster": clusterURL})
-
-	state, err = p.jenkins.State(ns, clusterURL)
-	if err != nil {
-		return
-	}
-	nsLogger.Infof("state : %q", state)
-
-	if state == clients.Idled {
-		// Unidle only if needed
-		nsLogger.Infof("Unidling jenkins")
-		if code, err = p.idler.UnIdle(ns, clusterURL); err != nil {
-			return
-		}
-	}
-	if code == http.StatusOK {
-		// XHR relies on 202 to retry and 200 to stop retrying and reload
-		// since we just started jenkins pods, change the code to 202 so
-		// that it retries
-		// SEE: static/html/index.html
-		code = http.StatusAccepted
-	}
-	return state, code, nil
-}
-*/

--- a/internal/proxy/ui_requests_test.go
+++ b/internal/proxy/ui_requests_test.go
@@ -73,7 +73,7 @@ func TestCorrectTokenWithJenkinsIdled(t *testing.T) {
 			Scheme:     "https",
 			Route:      "jenkins-namespace-jenkins.test_route",
 		}
-		assert.True(t, ok, "item object is of type cache item")
+		assert.True(t, ok, "item object should be of type cache item")
 		assert.Equal(t, info, cacheItem)
 	}
 }
@@ -140,7 +140,7 @@ func TestWithTokenJenkinsRunningAndLoginSuccessful(t *testing.T) {
 			Scheme:     "https",
 			Route:      "jenkins-namespace-jenkins.test_route",
 		}
-		assert.True(t, ok, "item object is of type cache item")
+		assert.True(t, ok, "item object should be of type cache item")
 		assert.Equal(t, info, cacheItem)
 	}
 }

--- a/internal/proxy/ui_requests_test.go
+++ b/internal/proxy/ui_requests_test.go
@@ -1,10 +1,24 @@
 package proxy
 
 import (
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
+	cache "github.com/patrickmn/go-cache"
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/testutils/mock"
+
+	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/auth"
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testTokenJSON = "%7B%22access_token%22%3A%22test_access_token%22%2C%22expires_in%22%3A2592000%2C%22not-before-policy%22%3Anull%2C%22refresh_expires_in%22%3A2592000%2C%22refresh_token%22%3A%22test_refresh_token%22%2C%22token_type%22%3A%22bearer%22%7D"
 )
 
 func TestBadToken(t *testing.T) {
@@ -14,5 +28,52 @@ func TestBadToken(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	p.handleJenkinsUIRequest(w, req, proxyLogger)
-	assert.Equal(t, 500, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestNoTokenRedirectstoAuthService(t *testing.T) {
+
+	p := Proxy{}
+	auth.SetDefaultClient(auth.NewClient("http://authURL"))
+	p.redirect = "http://redirect"
+
+	req := httptest.NewRequest("GET", "http://proxy/v1", nil)
+	w := httptest.NewRecorder()
+
+	p.handleJenkinsUIRequest(w, req, proxyLogger)
+	assert.Equal(t, http.StatusTemporaryRedirect, w.Code)
+	assert.Equal(t, w.Header().Get("Location"), "http://authURL/api/login?redirect=http:%2F%2Fredirect%2Fv1")
+}
+
+func TestCorrectTokenWithJenkinsIdled(t *testing.T) {
+	m := make(map[string]string)
+	m["Valid_OpenShift_API_URL"] = "test_route"
+	p := Proxy{
+		tenant:     &mock.Tenant{},
+		idler:      mock.NewMockIdler("", clients.Idled, false),
+		clusters:   m,
+		ProxyCache: cache.New(15*time.Minute, 10*time.Minute),
+	}
+	p.redirect = "http://redirect"
+
+	auth.SetDefaultClient(auth.NewMockAuth("http://authURL"))
+
+	req := httptest.NewRequest("GET", "http://proxy/v1?token_json="+testTokenJSON, nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "JSESSIONID." + uuid.NewV4().String(),
+		Value: uuid.NewV4().String(),
+	})
+
+	w := httptest.NewRecorder()
+
+	p.handleJenkinsUIRequest(w, req, proxyLogger)
+	assert.Equal(t, http.StatusFound, w.Code)
+	setCookieHeaders := w.Header()["Set-Cookie"]
+
+	assert.Equal(t, 2, len(setCookieHeaders))
+	for _, a := range setCookieHeaders {
+		fmt.Println(a)
+	}
+	assert.Contains(t, setCookieHeaders[0], "JSESSIONID")
+	assert.Contains(t, setCookieHeaders[1], "JenkinsIdled=")
 }

--- a/internal/proxy/ui_requests_test.go
+++ b/internal/proxy/ui_requests_test.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -57,9 +56,7 @@ func TestCorrectTokenWithJenkinsIdled(t *testing.T) {
 
 	setCookieHeaders := w.Header()["Set-Cookie"]
 	assert.Equal(t, 2, len(setCookieHeaders))
-	for _, a := range setCookieHeaders {
-		fmt.Println(a)
-	}
+
 	assert.Contains(t, setCookieHeaders[0], "JSESSIONID")
 	assert.Contains(t, setCookieHeaders[0], "Expires")
 	assert.Contains(t, setCookieHeaders[1], "JenkinsIdled=")
@@ -162,9 +159,6 @@ func TestExpireCookieIfNotInCache(t *testing.T) {
 	p.handleJenkinsUIRequest(w, req, proxyLogger)
 	setCookieHeaders := w.Header()["Set-Cookie"]
 	assert.Equal(t, 2, len(setCookieHeaders))
-	for _, a := range setCookieHeaders {
-		fmt.Println(a)
-	}
 
 	assert.Contains(t, setCookieHeaders[0], "JSESSIONID")
 	assert.Contains(t, setCookieHeaders[0], "Expires")

--- a/internal/proxy/ui_requests_test.go
+++ b/internal/proxy/ui_requests_test.go
@@ -125,9 +125,6 @@ func TestWithTokenJenkinsRunningAndLoginSuccessful(t *testing.T) {
 
 	setCookieHeaders := w.Header()["Set-Cookie"]
 	assert.Equal(t, 3, len(setCookieHeaders))
-	for _, a := range setCookieHeaders {
-		fmt.Println(a)
-	}
 
 	assert.Contains(t, setCookieHeaders[0], "JSESSIONID")
 	assert.Contains(t, setCookieHeaders[0], "Expires")
@@ -149,4 +146,26 @@ func TestWithTokenJenkinsRunningAndLoginSuccessful(t *testing.T) {
 		assert.True(t, ok, "item object is of type cache item")
 		assert.Equal(t, info, cacheItem)
 	}
+}
+
+func TestExpireCookieIfNotInCache(t *testing.T) {
+	p := NewMockProxy("")
+
+	req := httptest.NewRequest("GET", "http://proxy", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "JSESSIONID." + uuid.NewV4().String(),
+		Value: uuid.NewV4().String(),
+	})
+
+	w := httptest.NewRecorder()
+
+	p.handleJenkinsUIRequest(w, req, proxyLogger)
+	setCookieHeaders := w.Header()["Set-Cookie"]
+	assert.Equal(t, 2, len(setCookieHeaders))
+	for _, a := range setCookieHeaders {
+		fmt.Println(a)
+	}
+
+	assert.Contains(t, setCookieHeaders[0], "JSESSIONID")
+	assert.Contains(t, setCookieHeaders[0], "Expires")
 }

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -63,3 +63,13 @@ func (p *Proxy) processTemplate(w http.ResponseWriter, ns string, requestLogEntr
 	err = tmplt.Execute(w, data)
 	return
 }
+
+// constructRoute returns Jenkins route based on a specific pattern
+func constructRoute(clusters map[string]string, clusterURL string, ns string) (string, string, error) {
+	appSuffix := clusters[clusterURL]
+	if len(appSuffix) == 0 {
+		return "", "", fmt.Errorf("could not find entry for cluster %s", clusterURL)
+	}
+	route := fmt.Sprintf("jenkins-%s.%s", ns, clusters[clusterURL])
+	return route, "https", nil
+}

--- a/internal/testutils/mock/mock_tenant.go
+++ b/internal/testutils/mock/mock_tenant.go
@@ -12,7 +12,19 @@ type Tenant struct {
 
 // GetTenantInfo returns a tenant information based on tenant id.
 func (t Tenant) GetTenantInfo(tenantID string) (ti clients.TenantInfo, err error) {
-	return
+	return clients.TenantInfo{
+		Data: clients.TenantInfoData{
+			Attributes: clients.Attributes{
+				Namespaces: []clients.Namespace{
+					clients.Namespace{
+						ClusterURL: "Valid_OpenShift_API_URL",
+						Type:       "jenkins",
+					},
+				},
+			},
+			ID: "",
+		},
+	}, nil
 }
 
 // GetNamespace mock gets namespace

--- a/internal/testutils/mock/mock_tenant.go
+++ b/internal/testutils/mock/mock_tenant.go
@@ -6,7 +6,7 @@ import (
 	"github.com/fabric8-services/fabric8-jenkins-proxy/internal/clients"
 )
 
-// Tenant is a simple client for fabric8-tenant.
+// Tenant is a mock client for fabric8-tenant.
 type Tenant struct {
 }
 
@@ -16,7 +16,7 @@ func (t Tenant) GetTenantInfo(tenantID string) (ti clients.TenantInfo, err error
 		Data: clients.TenantInfoData{
 			Attributes: clients.Attributes{
 				Namespaces: []clients.Namespace{
-					clients.Namespace{
+					{
 						ClusterURL: "Valid_OpenShift_API_URL",
 						Type:       "jenkins",
 					},
@@ -30,15 +30,14 @@ func (t Tenant) GetTenantInfo(tenantID string) (ti clients.TenantInfo, err error
 // GetNamespace mock gets namespace
 func (t Tenant) GetNamespace(accessToken string) (namespace clients.Namespace, err error) {
 	if accessToken == "ValidToken" {
-		namespace = clients.Namespace{
+		return clients.Namespace{
 			ClusterURL: "Valid_OpenShift_API_URL",
 			Name:       "namespace-jenkins",
 			State:      "",
 			Type:       "jenkins",
-		}
-		return
+		}, nil
+
 	}
 
-	err = errors.New("Invalid Token")
-	return
+	return clients.Namespace{}, errors.New("Invalid Token")
 }

--- a/internal/testutils/mock/mock_tenant.go
+++ b/internal/testutils/mock/mock_tenant.go
@@ -19,6 +19,7 @@ func (t Tenant) GetTenantInfo(tenantID string) (ti clients.TenantInfo, err error
 					{
 						ClusterURL: "Valid_OpenShift_API_URL",
 						Type:       "jenkins",
+						Name:       "namespace-jenkins",
 					},
 				},
 			},


### PR DESCRIPTION
Currently, if session cookie is invalid, proxy does not check its
validity and passes the request to Jenkins considering that user is
logged in. Jenkins finds that cookie is not valid, but it can't expire
that cookie since it was setup by proxy. It will try to relogin user by
redirecting which will pass directly to jenkins again since session
cookie exists. And thus we are in a loop, leading to too many redirect
situation.

In proxy, check if cookie is valid. If it is not expire the cookie and
clear relevant cache. This will ask user to relogin without directly
passing the request to jenkins.

Fixes #321 and #336