### PR TITLE
[WIP] API for metadata removal: GDPR compliance

### DIFF
--- a/cmd/fabric8-jenkins-proxy/main.go
+++ b/cmd/fabric8-jenkins-proxy/main.go
@@ -150,7 +150,9 @@ func startWorkers(
 		}
 	}()
 
-	api := api.NewAPI(store)
+	tenant := clients.NewTenant(config.GetTenantURL(), config.GetAuthToken())
+
+	api := api.NewAPI(store, tenant)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -173,7 +175,6 @@ func startWorkers(
 		}
 	}()
 
-	tenant := clients.NewTenant(config.GetTenantURL(), config.GetAuthToken())
 	idler := clients.NewIdler(config.GetIdlerURL())
 	jenkinsAPI := jenkinsapi.NewJenkinsAPI(&tenant, idler)
 	wg.Add(1)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -15,6 +15,7 @@ func CreateAPIRouter(api api.ProxyAPI) *httprouter.Router {
 	// Create router for API
 	proxyRouter := httprouter.New()
 	proxyRouter.GET("/api/info/:namespace", api.Info)
+	proxyRouter.DELETE("/api/clear/metadata", api.Clear)
 	proxyRouter.Handler("GET", "/metrics", promhttp.Handler())
 	return proxyRouter
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -48,6 +48,10 @@ func (i *mockProxyAPI) Info(w http.ResponseWriter, r *http.Request, ps httproute
 	w.WriteHeader(http.StatusOK)
 }
 
+func (i *mockProxyAPI) Clear(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	w.WriteHeader(http.StatusOK)
+}
+
 type mockJenkinsAPI struct{}
 
 // Start mock returns the Jenkins status for the current user

--- a/internal/storage/db_store.go
+++ b/internal/storage/db_store.go
@@ -69,6 +69,11 @@ func (s *DBStore) DeleteRequest(r *Request) error {
 	return s.db.Delete(r).Error
 }
 
+// DeleteRequestsUser deletes requests of a namespace from the database.
+func (s *DBStore) DeleteRequestsUser(ns string) error {
+	return s.db.Unscoped().Table("requests").Where("namespace = ?", ns).Delete(&Request{}).Error
+}
+
 // CreateStatistics creates an entry of Statistics in the database.
 func (s *DBStore) CreateStatistics(o *Statistics) error {
 	return s.db.Create(o).Error
@@ -87,6 +92,11 @@ func (s *DBStore) GetStatisticsUser(ns string) (o *Statistics, notFound bool, er
 	err = d.Error
 	notFound = d.RecordNotFound()
 	return
+}
+
+// DeleteStatisticsUser deletes Statistics of a namespace from the database.
+func (s *DBStore) DeleteStatisticsUser(ns string) error {
+	return s.db.Unscoped().Table("statistics").Where("namespace = ?", ns).Delete(&Statistics{}).Error
 }
 
 // LogStats logs number of cached number of cached requests and statistics entries count.

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -24,10 +24,12 @@ type Store interface {
 	GetUsers() (result []string, err error)
 	GetRequestsCount(ns string) (result int, err error)
 	DeleteRequest(r *Request) error
+	DeleteRequestsUser(ns string) error
 
 	CreateStatistics(o *Statistics) error
 	UpdateStatistics(o *Statistics) error
 	GetStatisticsUser(ns string) (o *Statistics, notFound bool, err error)
+	DeleteStatisticsUser(ns string) error
 
 	LogStats()
 }

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -42,6 +42,10 @@ func (m *mockStore) DeleteRequest(r *Request) error {
 	return nil
 }
 
+func (m *mockStore) DeleteRequestsUser(ns string) error {
+	return nil
+}
+
 func (m *mockStore) CreateStatistics(o *Statistics) error {
 	return nil
 }
@@ -52,6 +56,11 @@ func (m *mockStore) UpdateStatistics(o *Statistics) error {
 
 func (m *mockStore) GetStatisticsUser(ns string) (o *Statistics, notFound bool, err error) {
 	return nil, false, nil
+}
+
+// DeleteStatisticsUser deletes Statistics of a namespace from the database.
+func (m *mockStore) DeleteStatisticsUser(ns string) error {
+	return nil
 }
 
 func (m *mockStore) LogStats() {


### PR DESCRIPTION
Provide an API which effectively do those SQL queries :

Find the jenkins namespace associated with the user,
say ${user_jenkins_namespace}

```
DELETE FROM statistics WHERE namespace = '${user_jenkins_namespace}';
DELETE FROM requests WHERE namespace = '${user_jenkins_namespace}';
```

Fixes #322